### PR TITLE
chore: remove samples from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
     <modules>
         <module>google-cloud-spanner-cassandra</module>
         <module>spanner-cassandra-launcher</module>
-        <module>samples</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Release breaks if samples module is included because the skipping configuration in it doesn't seem to work.