### PR TITLE
ci: disable lint check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,18 +97,18 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: javadoc
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 11
-    - run: java -version
-    - run: .kokoro/build.sh
-      env:
-        JOB_TYPE: lint
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: actions/setup-java@v4
+  #     with:
+  #       distribution: temurin
+  #       java-version: 11
+  #   - run: java -version
+  #   - run: .kokoro/build.sh
+  #     env:
+  #       JOB_TYPE: lint
   clirr:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This check is not compatible with newest g3 formatter extension. Running it locally is also not working. Thus we temporarily disable it.