### PR TITLE
feat: Enable Leader-Aware Routing by default for all write operations

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.adapter;
 
 import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
 
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.protobuf.ByteString;
 import com.google.spanner.adapter.v1.AdaptMessageRequest;
@@ -62,7 +63,8 @@ final class AdapterClientWrapper {
    * @return An {@link Optional} containing the byte array payload of the adapter's response, or
    *     {@link Optional#empty()} if no response is received.
    */
-  Optional<byte[]> sendGrpcRequest(byte[] payload, Map<String, String> attachments) {
+  Optional<byte[]> sendGrpcRequest(
+      byte[] payload, Map<String, String> attachments, ApiCallContext context) {
     AdaptMessageRequest request =
         AdaptMessageRequest.newBuilder()
             .setName(sessionManager.getSession().getName())
@@ -75,7 +77,7 @@ final class AdapterClientWrapper {
 
     try {
       ServerStream<AdaptMessageResponse> serverStream =
-          adapterClient.adaptMessageCallable().call(request);
+          adapterClient.adaptMessageCallable().call(request, context);
       for (AdaptMessageResponse adaptMessageResponse : serverStream) {
         adaptMessageResponse.getStateUpdatesMap().forEach(attachmentsCache::put);
         collectedPayloads.add(adaptMessageResponse.getPayload());

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -248,6 +248,7 @@ final class DriverConnectionHandler implements Runnable {
    * @return A {@link PreparePayloadResult} containing the result of the operation.
    */
   private PreparePayloadResult preparePayload(byte[] payload) {
+    // TODO: replace with Unpooled.wrappedBuffer(...) to avoid an extra memory copy.
     ByteBuf payloadBuf = byteBufAllocator.buffer(payload.length);
     payloadBuf.writeBytes(payload);
     Frame frame = serverFrameCodec.decode(payloadBuf);

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -25,40 +25,32 @@ import java.util.Optional;
  * gRPC request.
  */
 public class PreparePayloadResult {
-  private Optional<byte[]> attachmentErrorResponse;
   private ApiCallContext context;
   private Map<String, String> attachments;
+  private Optional<byte[]> attachmentErrorResponse;
 
   public PreparePayloadResult(
+      ApiCallContext context,
       Map<String, String> attachments,
-      Optional<byte[]> attachmentErrorResponse,
-      ApiCallContext context) {
+      Optional<byte[]> attachmentErrorResponse) {
+    this.context = context;
     this.attachments = attachments;
     this.attachmentErrorResponse = attachmentErrorResponse;
-    this.context = context;
+  }
+
+  public PreparePayloadResult(ApiCallContext context, Map<String, String> attachments) {
+    this(context, attachments, Optional.empty());
   }
 
   public Map<String, String> getAttachments() {
     return attachments;
   }
 
-  public void setAttachments(Map<String, String> attachments) {
-    this.attachments = attachments;
-  }
-
   public Optional<byte[]> getAttachmentErrorResponse() {
     return attachmentErrorResponse;
   }
 
-  public void setAttachmentErrorResponse(Optional<byte[]> attachmentErrorResponse) {
-    this.attachmentErrorResponse = attachmentErrorResponse;
-  }
-
   public ApiCallContext getContext() {
     return context;
-  }
-
-  public void setContext(ApiCallContext context) {
-    this.context = context;
   }
 }

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.google.cloud.spanner.adapter;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An object used to encapsulate the result of preparing the Adapter payload prior to sending the
+ * gRPC request.
+ */
+public class PreparePayloadResult {
+  private Optional<byte[]> attachmentErrorResponse;
+  private ApiCallContext context;
+  private Map<String, String> attachments;
+
+  public PreparePayloadResult(
+      Map<String, String> attachments,
+      Optional<byte[]> attachmentErrorResponse,
+      ApiCallContext context) {
+    this.attachments = attachments;
+    this.attachmentErrorResponse = attachmentErrorResponse;
+    this.context = context;
+  }
+
+  public Map<String, String> getAttachments() {
+    return attachments;
+  }
+
+  public void setAttachments(Map<String, String> attachments) {
+    this.attachments = attachments;
+  }
+
+  public Optional<byte[]> getAttachmentErrorResponse() {
+    return attachmentErrorResponse;
+  }
+
+  public void setAttachmentErrorResponse(Optional<byte[]> attachmentErrorResponse) {
+    this.attachmentErrorResponse = attachmentErrorResponse;
+  }
+
+  public ApiCallContext getContext() {
+    return context;
+  }
+
+  public void setContext(ApiCallContext context) {
+    this.context = context;
+  }
+}

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/util/StringUtils.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/util/StringUtils.java
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.google.cloud.spanner.adapter.util;
+
+/**
+ * Utility class for handling {@link String} objects.
+ *
+ * <p>This class cannot be instantiated.
+ */
+public final class StringUtils {
+
+  private StringUtils() {
+    throw new IllegalStateException("Utility class cannot be instantiated");
+  }
+
+  /**
+   * Returns true if `input` starts with `prefix`, excluding leading whitespaces and doing a
+   * case-insensitive comparison.
+   */
+  public static boolean startsWith(String input, String prefix) {
+    if (input == null || prefix == null) {
+      return false;
+    }
+
+    // Efficiently trim leading whitespace without creating a new String object if unnecessary.
+    int i = 0;
+    while (i < input.length() && Character.isWhitespace(input.charAt(i))) {
+      i++;
+    }
+
+    // Check if the remaining part starts with `prefix` (case-insensitive).
+    // Using regionMatches for efficiency as it avoids substring creation.
+    return input.regionMatches(true, i, prefix, 0, prefix.length());
+  }
+}

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -155,7 +155,7 @@ public final class DriverConnectionHandlerTest {
   @Test
   public void successfulDmlExecuteMessage() throws IOException {
     // Add the `W` prefix to indicate that this query originates from a prepared DML statement.
-    byte[] queryId = "W123".getBytes();
+    byte[] queryId = "W123".getBytes(StandardCharsets.UTF_8.name());
     byte[] validPayload = createExecuteMessage(queryId);
     Optional<byte[]> grpcResponse =
         Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -35,6 +35,8 @@ import com.datastax.oss.protocol.internal.request.Execute;
 import com.datastax.oss.protocol.internal.request.Prepare;
 import com.datastax.oss.protocol.internal.request.Query;
 import com.datastax.oss.protocol.internal.request.query.QueryOptions;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import java.io.ByteArrayInputStream;
@@ -49,6 +51,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public final class DriverConnectionHandlerTest {
 
@@ -56,6 +59,8 @@ public final class DriverConnectionHandlerTest {
   private static final FrameCodec<ByteBuf> clientFrameCodec =
       FrameCodec.defaultClient(
           new ByteBufPrimitiveCodec(ByteBufAllocator.DEFAULT), Compressor.none());
+  private static final ArgumentCaptor<ApiCallContext> contextCaptor =
+      ArgumentCaptor.forClass(ApiCallContext.class);
   private AdapterClientWrapper mockAdapterClient;
   private Socket mockSocket;
   private ByteArrayOutputStream outputStream;
@@ -76,13 +81,35 @@ public final class DriverConnectionHandlerTest {
     Optional<byte[]> grpcResponse =
         Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
-    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any())).thenReturn(grpcResponse);
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
 
     DriverConnectionHandler handler = new DriverConnectionHandler(mockSocket, mockAdapterClient);
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders()).isEmpty();
+  }
+
+  @Test
+  public void successfulDmlQueryMessage() throws IOException {
+    byte[] validPayload = createDmlQueryMessage();
+    Optional<byte[]> grpcResponse =
+        Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
+    when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
+
+    DriverConnectionHandler handler = new DriverConnectionHandler(mockSocket, mockAdapterClient);
+    handler.run();
+
+    assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
+    verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders())
+        .containsExactly("x-goog-spanner-route-to-leader", ImmutableList.of("true"));
   }
 
   @Test
@@ -91,13 +118,16 @@ public final class DriverConnectionHandlerTest {
     Optional<byte[]> grpcResponse =
         Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
-    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any())).thenReturn(grpcResponse);
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
 
     DriverConnectionHandler handler = new DriverConnectionHandler(mockSocket, mockAdapterClient);
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders()).isEmpty();
   }
 
   @Test
@@ -107,7 +137,8 @@ public final class DriverConnectionHandlerTest {
     Optional<byte[]> grpcResponse =
         Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
-    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any())).thenReturn(grpcResponse);
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
     AttachmentsCache AttachmentsCache = new AttachmentsCache(1);
     AttachmentsCache.put("pqid/" + new String(queryId, StandardCharsets.UTF_8.name()), "query");
     when(mockAdapterClient.getAttachmentsCache()).thenReturn(AttachmentsCache);
@@ -117,6 +148,32 @@ public final class DriverConnectionHandlerTest {
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders()).isEmpty();
+  }
+
+  @Test
+  public void successfulDmlExecuteMessage() throws IOException {
+    // Add the `W` prefix to indicate that this query originates from a prepared DML statement.
+    byte[] queryId = "W123".getBytes();
+    byte[] validPayload = createExecuteMessage(queryId);
+    Optional<byte[]> grpcResponse =
+        Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
+    when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
+    AttachmentsCache AttachmentsCache = new AttachmentsCache(1);
+    AttachmentsCache.put("pqid/" + new String(queryId, StandardCharsets.UTF_8.name()), "query");
+    when(mockAdapterClient.getAttachmentsCache()).thenReturn(AttachmentsCache);
+
+    DriverConnectionHandler handler = new DriverConnectionHandler(mockSocket, mockAdapterClient);
+    handler.run();
+
+    assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
+    verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders())
+        .containsExactly("x-goog-spanner-route-to-leader", ImmutableList.of("true"));
   }
 
   @Test
@@ -132,7 +189,7 @@ public final class DriverConnectionHandlerTest {
     handler.run();
 
     assertThat(outputStream.toByteArray()).isEqualTo(response);
-    verify(mockAdapterClient, never()).sendGrpcRequest(any(), any());
+    verify(mockAdapterClient, never()).sendGrpcRequest(any(), any(), any());
     verify(mockSocket).close();
   }
 
@@ -143,7 +200,8 @@ public final class DriverConnectionHandlerTest {
     Optional<byte[]> grpcResponse =
         Optional.of("gRPC response".getBytes(StandardCharsets.UTF_8.name()));
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
-    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any())).thenReturn(grpcResponse);
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
+        .thenReturn(grpcResponse);
     AttachmentsCache AttachmentsCache = new AttachmentsCache(1);
     AttachmentsCache.put("pqid/" + new String(queryId, StandardCharsets.UTF_8.name()), "query");
     when(mockAdapterClient.getAttachmentsCache()).thenReturn(AttachmentsCache);
@@ -153,6 +211,9 @@ public final class DriverConnectionHandlerTest {
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
+    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().getExtraHeaders())
+        .containsExactly("x-goog-spanner-route-to-leader", ImmutableList.of("true"));
   }
 
   @Test
@@ -168,7 +229,7 @@ public final class DriverConnectionHandlerTest {
     handler.run();
 
     assertThat(outputStream.toByteArray()).isEqualTo(response);
-    verify(mockAdapterClient, never()).sendGrpcRequest(any(), any());
+    verify(mockAdapterClient, never()).sendGrpcRequest(any(), any(), any());
     verify(mockSocket).close();
   }
 
@@ -218,11 +279,15 @@ public final class DriverConnectionHandlerTest {
   }
 
   private static byte[] createQueryMessage() {
-    return encodeMessage(new Query("SELECT * FROM T"));
+    return encodeMessage(new Query("SELECT * FROM ks.T"));
+  }
+
+  private static byte[] createDmlQueryMessage() {
+    return encodeMessage(new Query("INSERT INTO ks.T (col) VALUES (1)"));
   }
 
   private static byte[] createPrepareMessage() {
-    return encodeMessage(new Prepare("SELECT * FROM T WHERE col = ?"));
+    return encodeMessage(new Prepare("SELECT * FROM ks.T WHERE col = ?"));
   }
 
   private static byte[] createExecuteMessage(byte[] queryId) {

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/StringUtilsTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/StringUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.google.cloud.spanner.adapter;
+
+import static com.google.cloud.spanner.adapter.util.StringUtils.startsWith;
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public final class StringUtilsTest {
+  public StringUtilsTest() {}
+
+  @Test
+  public void stringStartsWith() {
+    assertThat(startsWith("AbC", "aB")).isTrue();
+    assertThat(startsWith("  AbC", "aB")).isTrue();
+
+    assertThat(startsWith("abc", "ax")).isFalse();
+    assertThat(startsWith("abc", null)).isFalse();
+    assertThat(startsWith(null, "x")).isFalse();
+    assertThat(startsWith(null, null)).isFalse();
+    assertThat(startsWith("", "x")).isFalse();
+  }
+}


### PR DESCRIPTION
This PR adds the `x-goog-spanner-route-to-leader` header to Adapter RPC contexts for write operations. The header is added to enable the Leader-Aware Routing feature, which aims to reduce cross-regional latency for write operations in a multi-region instance.