### PR TITLE
chore: optimize ByteBuf handling

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -225,10 +226,7 @@ final class DriverConnectionHandler implements Runnable {
   }
 
   private int load32BigEndian(byte[] bytes, int offset) {
-    return (bytes[offset] << 24)
-        | ((bytes[offset + 1] & 0xFF) << 16)
-        | ((bytes[offset + 2] & 0xFF) << 8)
-        | (bytes[offset + 3] & 0xFF);
+    return ByteBuffer.wrap(bytes, offset, 4).getInt();
   }
 
   /**

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -247,7 +247,7 @@ final class DriverConnectionHandler implements Runnable {
     Frame frame = serverFrameCodec.decode(payloadBuf);
     payloadBuf.release();
 
-    Map<String, String> attachments = new HashMap<String, String>();
+    Map<String, String> attachments = new HashMap<>();
     if (frame.message instanceof Execute) {
       return prepareExecuteMessage((Execute) frame.message, attachments);
     } else if (frame.message instanceof Batch) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -32,13 +32,13 @@ import com.google.api.gax.rpc.ApiCallContext;
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,9 +63,9 @@ final class DriverConnectionHandler implements Runnable {
   private final AdapterClientWrapper adapterClientWrapper;
   private final GrpcCallContext defaultContext;
   private final GrpcCallContext defaultContextWithLAR;
-
   private static final Map<String, List<String>> ROUTE_TO_LEADER_HEADER_MAP =
       ImmutableMap.of(ROUTE_TO_LEADER_HEADER_KEY, Collections.singletonList("true"));
+  private static final Map<String, String> EMPTY_ATTACHMENTS = Collections.emptyMap();
 
   /**
    * Constructor for DriverConnectionHandler.
@@ -88,9 +88,7 @@ final class DriverConnectionHandler implements Runnable {
 
     try (BufferedInputStream inputStream = new BufferedInputStream(socket.getInputStream());
         BufferedOutputStream outputStream = new BufferedOutputStream(socket.getOutputStream())) {
-
-      processRequest(inputStream, outputStream);
-
+      processRequestsLoop(inputStream, outputStream);
     } catch (IOException e) {
       LOG.error(
           "Exception handling connection from {}: {}",
@@ -106,12 +104,11 @@ final class DriverConnectionHandler implements Runnable {
     }
   }
 
-  private void processRequest(InputStream inputStream, OutputStream outputStream)
+  private void processRequestsLoop(InputStream inputStream, OutputStream outputStream)
       throws IOException {
     // Keep processing until End-Of-Stream is reached on the input
     while (true) {
-      Optional<byte[]> response; // Using Optional to handle different response scenarios
-
+      Optional<byte[]> response;
       try {
         // 1. Read and construct the payload from the input stream
         byte[] payload = constructPayload(inputStream);
@@ -228,7 +225,10 @@ final class DriverConnectionHandler implements Runnable {
   }
 
   private int load32BigEndian(byte[] bytes, int offset) {
-    return ByteBuffer.wrap(bytes, offset, 4).getInt();
+    return (bytes[offset] << 24)
+        | ((bytes[offset + 1] & 0xFF) << 16)
+        | ((bytes[offset + 2] & 0xFF) << 8)
+        | (bytes[offset + 3] & 0xFF);
   }
 
   /**
@@ -245,24 +245,20 @@ final class DriverConnectionHandler implements Runnable {
    * @return A {@link PreparePayloadResult} containing the result of the operation.
    */
   private PreparePayloadResult preparePayload(byte[] payload) {
-    // TODO: replace with Unpooled.wrappedBuffer(...) to avoid an extra memory copy.
-    ByteBuf payloadBuf = byteBufAllocator.buffer(payload.length);
-    payloadBuf.writeBytes(payload);
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
     Frame frame = serverFrameCodec.decode(payloadBuf);
     payloadBuf.release();
 
-    Map<String, String> attachments = new HashMap();
+    Map<String, String> attachments = new HashMap<String, String>();
     if (frame.message instanceof Execute) {
       return prepareExecuteMessage((Execute) frame.message, attachments);
-    }
-    if (frame.message instanceof Batch) {
+    } else if (frame.message instanceof Batch) {
       return prepareBatchMessage((Batch) frame.message, attachments);
-    }
-    if (frame.message instanceof Query) {
+    } else if (frame.message instanceof Query) {
       return prepareQueryMessage((Query) frame.message, attachments);
+    } else {
+      return new PreparePayloadResult(defaultContext, EMPTY_ATTACHMENTS);
     }
-
-    return new PreparePayloadResult(defaultContext, attachments);
   }
 
   private PreparePayloadResult prepareExecuteMessage(

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
@@ -70,6 +70,7 @@ public final class SpannerCqlSessionBuilder
     return this;
   }
 
+  /** Sets the number of gRPC channels to use. By default 4 channels are created. */
   public SpannerCqlSessionBuilder setNumGrpcChannels(int numGrpcChannels) {
     this.numGrpcChannels = numGrpcChannels;
     return this;


### PR DESCRIPTION
Use `Unpooled.wrappedBuffer` instead of `byteBufAllocator.buffer().writeBytes()` which does memory copy. `Unpooled.wrappedBuffer()` creates a `ByteBuf` that directly wraps the existing `byte[]` without copying its contents. 

Basic benchmark comparison: 
```
Benchmark                 Mode  Cnt    Score    Error  Units
benchmarkAllocateAndCopy  avgt    5  289.054 ± 12.868  ns/op
benchmarkWrap             avgt    5   92.813 ±  3.821  ns/op
```

This result demonstrate the `benchmarkWrap` method (using `Unpooled.wrappedBuffer`) is significantly faster (lower average time per operation) than `benchmarkAllocateAndCopy` (using `byteBufAllocator.buffer().writeBytes()`), confirming the efficiency gain from avoiding the explicit data copy.

This PR also contains small renaming and use of `EMPTY_ATTACHMENTS` for better readability. This PR also adds comment for `setNumGrpcChannels()` method.