### PR TITLE
feat: Add support for setting the max commit delay

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
@@ -82,6 +82,8 @@ final class Adapter {
       int port,
       int numGrpcChannels,
       Optional<Duration> maxCommitDelay) {
+    // TODO: Encapsulate arguments in an Options class to accomodate future fields without having to
+    // pass them individually.
     this.databaseUri = databaseUri;
     this.inetAddress = inetAddress;
     this.port = port;

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
@@ -28,6 +28,8 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -58,6 +60,7 @@ final class Adapter {
   private final int port;
   private final String databaseUri;
   private final int numGrpcChannels;
+  private final Optional<Duration> maxCommitDelay;
   private AdapterClientWrapper adapterClientWrapper;
   private ServerSocket serverSocket;
   private ExecutorService executor;
@@ -71,12 +74,19 @@ final class Adapter {
    * @param port The local TCP port number that the adapter server should listen on.
    * @param numGrpcChannels The number of gRPC channels to use for communication with the backend
    *     Spanner service.
+   * @param maxCommitDelay The max commit delay to set in requests to optimize write throughput.
    */
-  Adapter(String databaseUri, InetAddress inetAddress, int port, int numGrpcChannels) {
+  Adapter(
+      String databaseUri,
+      InetAddress inetAddress,
+      int port,
+      int numGrpcChannels,
+      Optional<Duration> maxCommitDelay) {
     this.databaseUri = databaseUri;
     this.inetAddress = inetAddress;
     this.port = port;
     this.numGrpcChannels = numGrpcChannels;
+    this.maxCommitDelay = maxCommitDelay;
   }
 
   /** Starts the adapter, initializing the local TCP server and handling client connections. */
@@ -160,7 +170,8 @@ final class Adapter {
     try {
       while (!Thread.currentThread().isInterrupted()) {
         final Socket clientSocket = serverSocket.accept();
-        executor.execute(new DriverConnectionHandler(clientSocket, adapterClientWrapper));
+        executor.execute(
+            new DriverConnectionHandler(clientSocket, adapterClientWrapper, maxCommitDelay));
         LOG.info("Accepted client connection from: {}", clientSocket.getRemoteSocketAddress());
       }
     } catch (SocketException e) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -41,6 +41,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -57,29 +58,41 @@ final class DriverConnectionHandler implements Runnable {
   private static final String PREPARED_QUERY_ID_ATTACHMENT_PREFIX = "pqid/";
   private static final char WRITE_ACTION_QUERY_ID_PREFIX = 'W';
   private static final String ROUTE_TO_LEADER_HEADER_KEY = "x-goog-spanner-route-to-leader";
+  private static final String MAX_COMMIT_DELAY_ATTACHMENT_KEY = "max_commit_delay";
   private static final ByteBufAllocator byteBufAllocator = ByteBufAllocator.DEFAULT;
   private static final FrameCodec<ByteBuf> serverFrameCodec =
       FrameCodec.defaultServer(new ByteBufPrimitiveCodec(byteBufAllocator), Compressor.none());
   private final Socket socket;
   private final AdapterClientWrapper adapterClientWrapper;
+  private final Optional<String> maxCommitDelayMillis;
   private final GrpcCallContext defaultContext;
   private final GrpcCallContext defaultContextWithLAR;
   private static final Map<String, List<String>> ROUTE_TO_LEADER_HEADER_MAP =
       ImmutableMap.of(ROUTE_TO_LEADER_HEADER_KEY, Collections.singletonList("true"));
-  private static final Map<String, String> EMPTY_ATTACHMENTS = Collections.emptyMap();
 
   /**
    * Constructor for DriverConnectionHandler.
    *
    * @param socket The client's socket.
    * @param adapterClientWrapper The adapter client wrapper used for gRPC communication.
+   * @param maxCommitDelay The max commit delay to set in requests to optimize write throughput.
    */
-  public DriverConnectionHandler(Socket socket, AdapterClientWrapper adapterClientWrapper) {
+  public DriverConnectionHandler(
+      Socket socket, AdapterClientWrapper adapterClientWrapper, Optional<Duration> maxCommitDelay) {
     this.socket = socket;
     this.adapterClientWrapper = adapterClientWrapper;
     this.defaultContext = GrpcCallContext.createDefault();
     this.defaultContextWithLAR =
         GrpcCallContext.createDefault().withExtraHeaders(ROUTE_TO_LEADER_HEADER_MAP);
+    if (maxCommitDelay.isPresent()) {
+      this.maxCommitDelayMillis = Optional.of(String.valueOf(maxCommitDelay.get().toMillis()));
+    } else {
+      this.maxCommitDelayMillis = Optional.empty();
+    }
+  }
+
+  public DriverConnectionHandler(Socket socket, AdapterClientWrapper adapterClientWrapper) {
+    this(socket, adapterClientWrapper, Optional.empty());
   }
 
   /** Runs the connection handler, processing incoming TCP data and sending gRPC requests. */
@@ -248,14 +261,19 @@ final class DriverConnectionHandler implements Runnable {
     payloadBuf.release();
 
     Map<String, String> attachments = new HashMap<>();
+    if ((frame.message instanceof Execute || frame.message instanceof Batch)
+        && maxCommitDelayMillis.isPresent()) {
+      attachments.put(MAX_COMMIT_DELAY_ATTACHMENT_KEY, maxCommitDelayMillis.get());
+    }
+
     if (frame.message instanceof Execute) {
       return prepareExecuteMessage((Execute) frame.message, attachments);
     } else if (frame.message instanceof Batch) {
       return prepareBatchMessage((Batch) frame.message, attachments);
     } else if (frame.message instanceof Query) {
-      return prepareQueryMessage((Query) frame.message, attachments);
+      return prepareQueryMessage((Query) frame.message);
     } else {
-      return new PreparePayloadResult(defaultContext, EMPTY_ATTACHMENTS);
+      return new PreparePayloadResult(defaultContext);
     }
   }
 
@@ -287,10 +305,10 @@ final class DriverConnectionHandler implements Runnable {
     return new PreparePayloadResult(defaultContextWithLAR, attachments, attachmentErrorResponse);
   }
 
-  private PreparePayloadResult prepareQueryMessage(Query message, Map<String, String> attachments) {
+  private PreparePayloadResult prepareQueryMessage(Query message) {
     ApiCallContext context =
         startsWith(message.query, "SELECT") ? defaultContext : defaultContextWithLAR;
-    return new PreparePayloadResult(context, attachments);
+    return new PreparePayloadResult(context);
   }
 
   private Optional<byte[]> prepareAttachmentForQueryId(

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -29,6 +29,7 @@ public class PreparePayloadResult {
   private ApiCallContext context;
   private Map<String, String> attachments;
   private Optional<byte[]> attachmentErrorResponse;
+  private static final Map<String, String> EMPTY_ATTACHMENTS = Collections.emptyMap();
 
   public PreparePayloadResult(
       ApiCallContext context,
@@ -44,7 +45,7 @@ public class PreparePayloadResult {
   }
 
   public PreparePayloadResult(ApiCallContext context) {
-    this(context, Collections.emptyMap(), Optional.empty());
+    this(context, EMPTY_ATTACHMENTS, Optional.empty());
   }
 
   public Map<String, String> getAttachments() {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -17,6 +17,7 @@ limitations under the License.
 package com.google.cloud.spanner.adapter;
 
 import com.google.api.gax.rpc.ApiCallContext;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,6 +41,10 @@ public class PreparePayloadResult {
 
   public PreparePayloadResult(ApiCallContext context, Map<String, String> attachments) {
     this(context, attachments, Optional.empty());
+  }
+
+  public PreparePayloadResult(ApiCallContext context) {
+    this(context, Collections.emptyMap(), Optional.empty());
   }
 
   public Map<String, String> getAttachments() {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
@@ -43,6 +43,7 @@ public final class SpannerCqlSessionBuilder
   private static final int DEFAULT_PORT = 9042;
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final int DEFAULT_NUM_GRPC_CHANNELS = 4;
+  private static final int LARGEST_MAX_COMMIT_DELAY_MILLIS = 500;
 
   private InetAddress iNetAddress;
   private int port;
@@ -79,7 +80,11 @@ public final class SpannerCqlSessionBuilder
     return this;
   }
 
-  /** Sets the max commit delay to use in requests. By default this argument is not set. */
+  // TODO: Add a code sample for setting this option.
+  /**
+   * Sets the max commit delay to use in requests. This will apply globally to all Batch and Execute
+   * DML requests. By default this argument is not set.
+   */
   public SpannerCqlSessionBuilder setMaxCommitDelay(Duration maxCommitDelay) {
     this.maxCommitDelay = Optional.of(maxCommitDelay);
     return this;
@@ -120,6 +125,7 @@ public final class SpannerCqlSessionBuilder
     checkDatabaseUri();
     checkContactPoints();
     checkNumGrpcChannels();
+    checkMaxCommitDelay();
   }
 
   private void checkDatabaseUri() {
@@ -164,6 +170,15 @@ public final class SpannerCqlSessionBuilder
   private void checkNumGrpcChannels() {
     if (numGrpcChannels <= 0) {
       throw new IllegalArgumentException("Number of gRPC channels should be greater than 0.");
+    }
+  }
+
+  private void checkMaxCommitDelay() {
+    if (maxCommitDelay.isPresent()
+        && (maxCommitDelay.get().isNegative()
+            || maxCommitDelay.get().toMillis() > LARGEST_MAX_COMMIT_DELAY_MILLIS)) {
+      throw new IllegalArgumentException(
+          "The max commit delay must be > 0 and < " + LARGEST_MAX_COMMIT_DELAY_MILLIS + "ms.");
     }
   }
 

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
@@ -23,6 +23,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -47,6 +49,7 @@ public final class SpannerCqlSessionBuilder
   private Adapter adapter;
   private int numGrpcChannels = DEFAULT_NUM_GRPC_CHANNELS;
   private String databaseUri = null;
+  private Optional<Duration> maxCommitDelay = Optional.empty();
 
   /**
    * Wraps the default CQL session with a SpannerCqlSession instance.
@@ -73,6 +76,12 @@ public final class SpannerCqlSessionBuilder
   /** Sets the number of gRPC channels to use. By default 4 channels are created. */
   public SpannerCqlSessionBuilder setNumGrpcChannels(int numGrpcChannels) {
     this.numGrpcChannels = numGrpcChannels;
+    return this;
+  }
+
+  /** Sets the max commit delay to use in requests. By default this argument is not set. */
+  public SpannerCqlSessionBuilder setMaxCommitDelay(Duration maxCommitDelay) {
+    this.maxCommitDelay = Optional.of(maxCommitDelay);
     return this;
   }
 
@@ -159,7 +168,7 @@ public final class SpannerCqlSessionBuilder
   }
 
   private void createAndStartAdapter() {
-    adapter = new Adapter(databaseUri, iNetAddress, port, numGrpcChannels);
+    adapter = new Adapter(databaseUri, iNetAddress, port, numGrpcChannels, maxCommitDelay);
     adapter.start();
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterTest.java
@@ -34,6 +34,7 @@ import com.google.spanner.adapter.v1.Session;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public final class AdapterTest {
 
   @Before
   public void setUp() {
-    adapter = new Adapter(TEST_DATABASE_URI, inetAddress, TEST_PORT, 4);
+    adapter = new Adapter(TEST_DATABASE_URI, inetAddress, TEST_PORT, 4, Optional.empty());
   }
 
   @Test

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -45,9 +45,11 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +63,8 @@ public final class DriverConnectionHandlerTest {
           new ByteBufPrimitiveCodec(ByteBufAllocator.DEFAULT), Compressor.none());
   private static final ArgumentCaptor<ApiCallContext> contextCaptor =
       ArgumentCaptor.forClass(ApiCallContext.class);
+  private static final ArgumentCaptor<Map<String, String>> attachmentsCaptor =
+      ArgumentCaptor.forClass(Map.class);
   private AdapterClientWrapper mockAdapterClient;
   private Socket mockSocket;
   private ByteArrayOutputStream outputStream;
@@ -140,16 +144,23 @@ public final class DriverConnectionHandlerTest {
     when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any()))
         .thenReturn(grpcResponse);
     AttachmentsCache AttachmentsCache = new AttachmentsCache(1);
-    AttachmentsCache.put("pqid/" + new String(queryId, StandardCharsets.UTF_8.name()), "query");
+    String preparedQueryKey = "pqid/" + new String(queryId, StandardCharsets.UTF_8.name());
+    AttachmentsCache.put(preparedQueryKey, "query");
     when(mockAdapterClient.getAttachmentsCache()).thenReturn(AttachmentsCache);
 
-    DriverConnectionHandler handler = new DriverConnectionHandler(mockSocket, mockAdapterClient);
+    // Use a max commit delay of 100 ms.
+    DriverConnectionHandler handler =
+        new DriverConnectionHandler(
+            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)));
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
-    verify(mockAdapterClient).sendGrpcRequest(any(), any(), contextCaptor.capture());
+    verify(mockAdapterClient)
+        .sendGrpcRequest(any(), attachmentsCaptor.capture(), contextCaptor.capture());
     assertThat(contextCaptor.getValue().getExtraHeaders()).isEmpty();
+    assertThat(attachmentsCaptor.getValue())
+        .containsExactly(preparedQueryKey, "query", "max_commit_delay", "100");
   }
 
   @Test

--- a/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
+++ b/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
@@ -17,6 +17,8 @@ limitations under the License.
 package com.google.cloud.spanner.adapter;
 
 import java.net.InetAddress;
+import java.time.Duration;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,8 @@ import org.slf4j.LoggerFactory;
  *   <li>{@code port}: (Optional) The port number to bind the service to. Defaults to 9042.
  *   <li>{@code numGrpcChannels}: (Optional) The number of gRPC channels to use for communication
  *       with Spanner. Defaults to 4.
+ *   <li>{@code maxCommitDelayMillis}: (Optional) The max commit delay to set in requests to
+ *       optimize write throughput, in milliseconds. Defaults to none.
  * </ul>
  *
  * Example usage:
@@ -45,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * -Dhost=127.0.0.1 \
  * -Dport=9042 \
  * -DnumGrpcChannels=4 \
+ * -DmaxCommitDelayMillis=100 \
  * -cp path/to/your/spanner-cassandra-launcher.jar com.google.cloud.spanner.adapter.SpannerCassandraLauncher
  * </pre>
  *
@@ -59,6 +64,7 @@ public class SpannerCassandraLauncher {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DEFAULT_PORT = "9042";
   private static final String DEFAULT_NUM_GRPC_CHANNELS = "4";
+  private static final String MAX_COMMIT_DELAY_PROP_KEY = "maxCommitDelayMillis";
 
   public static void main(String[] args) throws Exception {
     final String databaseUri = System.getProperty(DATABASE_URI_PROP_KEY);
@@ -67,13 +73,20 @@ public class SpannerCassandraLauncher {
     final int port = Integer.parseInt(System.getProperty(PORT_PROP_KEY, DEFAULT_PORT));
     final int numGrpcChannels =
         Integer.parseInt(System.getProperty(NUM_GRPC_CHANNELS_PROP_KEY, DEFAULT_NUM_GRPC_CHANNELS));
+    final String maxCommitDelayProperty = System.getProperty(MAX_COMMIT_DELAY_PROP_KEY);
+    final Optional<Duration> maxCommitDelay;
+    if (maxCommitDelayProperty != null) {
+      maxCommitDelay = Optional.of(Duration.ofMillis(Integer.parseInt(maxCommitDelayProperty)));
+    } else {
+      maxCommitDelay = Optional.empty();
+    }
 
     if (databaseUri == null) {
       throw new IllegalArgumentException(
           "Spanner database URI not set. Please set it using -DdatabaseUri option.");
     }
 
-    Adapter adapter = new Adapter(databaseUri, inetAddress, port, numGrpcChannels);
+    Adapter adapter = new Adapter(databaseUri, inetAddress, port, numGrpcChannels, maxCommitDelay);
 
     Runtime.getRuntime()
         .addShutdownHook(
@@ -87,11 +100,13 @@ public class SpannerCassandraLauncher {
                 }));
 
     LOG.info(
-        "Starting Adapter for Spanner database {} on {}:{} with {} gRPC channels...",
+        "Starting Adapter for Spanner database {} on {}:{} with {} gRPC channels and max commit"
+            + " delay of {}...",
         databaseUri,
         inetAddress,
         port,
-        numGrpcChannels);
+        numGrpcChannels,
+        maxCommitDelayProperty);
 
     adapter.start();
 

--- a/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
+++ b/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * -Dhost=127.0.0.1 \
  * -Dport=9042 \
  * -DnumGrpcChannels=4 \
- * -DmaxCommitDelayMillis=100 \
+ * -DmaxCommitDelayMillis=5 \
  * -cp path/to/your/spanner-cassandra-launcher.jar com.google.cloud.spanner.adapter.SpannerCassandraLauncher
  * </pre>
  *


### PR DESCRIPTION
Adds support for setting the max commit delay when the client is used as an in-process dependency or as a sidecar proxy. This argument is used to optimize write throughput in Spanner, refer to https://cloud.google.com/spanner/docs/throughput-optimized-writes for more details.