### PR TITLE
fix: handle keyspace with hyphens on client side

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
@@ -15,16 +15,6 @@ limitations under the License.
 */
 package com.google.cloud.spanner.adapter;
 
-import com.google.api.gax.core.GaxProperties;
-import com.google.api.gax.grpc.ChannelPoolSettings;
-import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
-import com.google.api.gax.rpc.FixedHeaderProvider;
-import com.google.api.gax.rpc.HeaderProvider;
-import com.google.api.pathtemplate.PathTemplate;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.base.Preconditions;
-import com.google.spanner.adapter.v1.AdapterClient;
-import com.google.spanner.adapter.v1.AdapterSettings;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -35,9 +25,22 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import javax.annotation.concurrent.NotThreadSafe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.grpc.ChannelPoolSettings;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Preconditions;
+import com.google.spanner.adapter.v1.AdapterClient;
+import com.google.spanner.adapter.v1.AdapterSettings;
 
 /** Manages client connections, acting as an intermediary for communication with Spanner. */
 @NotThreadSafe
@@ -100,7 +103,7 @@ final class Adapter {
     this.port = port;
     this.numGrpcChannels = numGrpcChannels;
     this.maxCommitDelay = maxCommitDelay;
-    this.keySpace = "test-hyphen";
+    this.keySpace = parseDatabaseName(databaseUri);
     this.sanitizeKeyspace = sanitizeKeyspace;
   }
 

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -16,10 +16,11 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import com.google.api.gax.rpc.ApiCallContext;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+
+import com.google.api.gax.rpc.ApiCallContext;
 
 /**
  * An object used to encapsulate the result of preparing the Adapter payload prior to sending the
@@ -29,6 +30,8 @@ public class PreparePayloadResult {
   private ApiCallContext context;
   private Map<String, String> attachments;
   private Optional<byte[]> attachmentErrorResponse;
+  // TODO: remove after server fix rolled out
+  public byte[] sanitizedPayload;
   private static final Map<String, String> EMPTY_ATTACHMENTS = Collections.emptyMap();
 
   public PreparePayloadResult(
@@ -38,6 +41,10 @@ public class PreparePayloadResult {
     this.context = context;
     this.attachments = attachments;
     this.attachmentErrorResponse = attachmentErrorResponse;
+  }
+
+  public void setSanitizedPayload(byte[] payload) {
+    this.sanitizedPayload = payload;
   }
 
   public PreparePayloadResult(ApiCallContext context, Map<String, String> attachments) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
@@ -205,7 +205,8 @@ public final class SpannerCqlSessionBuilder
   }
 
   private void createAndStartAdapter() {
-    adapter = new Adapter(host, databaseUri, iNetAddress, port, numGrpcChannels, maxCommitDelay);
+    adapter =
+        new Adapter(host, databaseUri, iNetAddress, port, numGrpcChannels, maxCommitDelay, false);
     adapter.start();
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterTest.java
@@ -57,7 +57,8 @@ public final class AdapterTest {
   @Before
   public void setUp() {
     adapter =
-        new Adapter(TEST_HOST, TEST_DATABASE_URI, inetAddress, TEST_PORT, 4, Optional.empty());
+        new Adapter(
+            TEST_HOST, TEST_DATABASE_URI, inetAddress, TEST_PORT, 4, Optional.empty(), false);
   }
 
   @Test

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -109,7 +109,7 @@ public final class DriverConnectionHandlerTest {
     // Use a max commit delay of 100 ms.
     DriverConnectionHandler handler =
         new DriverConnectionHandler(
-            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)));
+            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test");
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
@@ -179,7 +179,7 @@ public final class DriverConnectionHandlerTest {
     // Use a max commit delay of 100 ms.
     DriverConnectionHandler handler =
         new DriverConnectionHandler(
-            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)));
+            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test");
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -109,7 +109,7 @@ public final class DriverConnectionHandlerTest {
     // Use a max commit delay of 100 ms.
     DriverConnectionHandler handler =
         new DriverConnectionHandler(
-            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test");
+            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test", false);
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
@@ -179,7 +179,7 @@ public final class DriverConnectionHandlerTest {
     // Use a max commit delay of 100 ms.
     DriverConnectionHandler handler =
         new DriverConnectionHandler(
-            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test");
+            mockSocket, mockAdapterClient, Optional.of(Duration.ofMillis(100)), "test", false);
     handler.run();
 
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/KeySpaceSanitizerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/KeySpaceSanitizerTest.java
@@ -107,6 +107,13 @@ public final class KeySpaceSanitizerTest {
   }
 
   @Test
+  public void testShouldNotMatchPartialNames() {
+    String keyspace = "my-keyspace";
+    String originalQuery = "SELECT * FROM my-keyspace-backup.users WHERE name = 'value';";
+    assertEquals(originalQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
   public void testShouldHandleMultipleOccurrences() {
     String keyspace = "ks-1";
     String originalQuery = "USE ks-1; SELECT * FROM ks-1.table1; UPDATE ks-1.table2 SET col=1;";
@@ -128,5 +135,21 @@ public final class KeySpaceSanitizerTest {
     String query = "SELECT * FROM ks-1.t";
     assertEquals(query, sanitizeHyphenFromKeyspace(query, null));
     assertEquals(query, sanitizeHyphenFromKeyspace(query, ""));
+  }
+
+  @Test
+  public void testShouldNotSanitizeKeyspaceWithinStringLiteralContent() {
+    String keyspace = "my-key-space";
+    String originalQuery = "UPDATE config.table SET value = '  my-key-space  ' WHERE id = 1;";
+    String sanitized = sanitizeHyphenFromKeyspace(originalQuery, keyspace);
+    assertEquals(originalQuery, sanitized);
+  }
+
+  @Test
+  public void testShouldNotSanitizeDoubleQuotedKeyspaceWithinStringLiteralContent() {
+    String keyspace = "my-key-space";
+    String originalQuery = "UPDATE config.table SET value = '\"my-key-space\"' WHERE id = 1;";
+    String sanitized = sanitizeHyphenFromKeyspace(originalQuery, keyspace);
+    assertEquals(originalQuery, sanitized);
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/KeySpaceSanitizerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/KeySpaceSanitizerTest.java
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+
+import static com.google.cloud.spanner.adapter.DriverConnectionHandler.sanitizeHyphenFromKeyspace;
+
+public final class KeySpaceSanitizerTest {
+  public KeySpaceSanitizerTest() {}
+
+  @Test
+  public void testSanitizeUseStatement() {
+    String originalQuery = "USE my-app-keyspace;";
+    String keyspace = "my-app-keyspace";
+    String expectedQuery = "USE my_app_keyspace;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testSanitizeUseStatementInQuotes() {
+    String originalQuery = "USE \"my-app-keyspace\";";
+    String keyspace = "my-app-keyspace";
+    String expectedQuery = "USE \"my_app_keyspace\";";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testSanitizeSelectStatement() {
+    String originalQuery = "SELECT * FROM my-app-keyspace.users;";
+    String keyspace = "my-app-keyspace";
+    String expectedQuery = "SELECT * FROM my_app_keyspace.users;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testSanitizeInsertStatement() {
+    String originalQuery =
+        "INSERT INTO complex-ks-name.user_actions (id, action) VALUES (uuid(), 'login');";
+    String keyspace = "complex-ks-name";
+    String expectedQuery =
+        "INSERT INTO complex_ks_name.user_actions (id, action) VALUES (uuid(), 'login');";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testSanitizeUpdateStatement() {
+    String originalQuery = "UPDATE another-keyspace.settings SET value = true WHERE id = 1;";
+    String keyspace = "another-keyspace";
+    String expectedQuery = "UPDATE another_keyspace.settings SET value = true WHERE id = 1;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testSanitizeDeleteStatement() {
+    String originalQuery = "DELETE FROM data-store.log_entries WHERE event_time < now();";
+    String keyspace = "data-store";
+    String expectedQuery = "DELETE FROM data_store.log_entries WHERE event_time < now();";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldNotChangeStringLiterals() {
+    String keyspace = "my-app-keyspace";
+    String originalQuery =
+        "INSERT INTO my_app_keyspace.logs (level, msg) VALUES ('info', 'Action related to"
+            + " my-app-keyspace');";
+    assertEquals(originalQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldHandleEscapedQuotesInLiterals() {
+    String keyspace = "my-keyspace";
+    String originalQuery =
+        "UPDATE my_keyspace.docs SET content = 'This isn''t my-keyspace, it''s something else.'"
+            + " WHERE id = 1;";
+    assertEquals(originalQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldBeCaseInsensitive() {
+    String keyspace = "my-app-keyspace";
+    String originalQuery = "SELECT * FROM MY-APP-KEYSPACE.users; USE my-App-keyspace;";
+    String expectedQuery = "SELECT * FROM my_app_keyspace.users; USE my_app_keyspace;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldHandleTrickyHyphenatedKeyspace() {
+    String keyspace = "h-hi";
+    String originalQuery = "SELECT * FROM h-hi.some_table;";
+    String expectedQuery = "SELECT * FROM h_hi.some_table;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldHandleMultipleOccurrences() {
+    String keyspace = "ks-1";
+    String originalQuery = "USE ks-1; SELECT * FROM ks-1.table1; UPDATE ks-1.table2 SET col=1;";
+    String expectedQuery = "USE ks_1; SELECT * FROM ks_1.table1; UPDATE ks_1.table2 SET col=1;";
+    assertEquals(expectedQuery, sanitizeHyphenFromKeyspace(originalQuery, keyspace));
+  }
+
+  @Test
+  public void testShouldReturnOriginalOnNoHyphenKeyspace() {
+    String originalQuery = "USE my_keyspace;";
+    assertSame(originalQuery, sanitizeHyphenFromKeyspace(originalQuery, "my_keyspace"));
+  }
+
+  @Test
+  public void testShouldHandleNullAndEmpty() {
+    assertEquals(sanitizeHyphenFromKeyspace(null, "ks-1"), null);
+    assertEquals("", sanitizeHyphenFromKeyspace("", "ks-1"));
+
+    String query = "SELECT * FROM ks-1.t";
+    assertEquals(query, sanitizeHyphenFromKeyspace(query, null));
+    assertEquals(query, sanitizeHyphenFromKeyspace(query, ""));
+  }
+}

--- a/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
+++ b/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.adapter;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SpannerCassandraLauncher {
   private static final Logger LOG = LoggerFactory.getLogger(SpannerCassandraLauncher.class);
-  private static final String DEFAULT_SPANNER_ENDPOINT = "spanner.googleapis.com:443";
+  private static final String DEFAULT_SPANNER_ENDPOINT =
+      "preprod-spanner.sandbox.googleapis.com:443";
   private static final String DATABASE_URI_PROP_KEY = "databaseUri";
   private static final String HOST_PROP_KEY = "host";
   private static final String PORT_PROP_KEY = "port";

--- a/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
+++ b/spanner-cassandra-launcher/src/main/java/com/google/cloud/spanner/adapter/SpannerCassandraLauncher.java
@@ -66,6 +66,7 @@ public class SpannerCassandraLauncher {
   private static final String DEFAULT_PORT = "9042";
   private static final String DEFAULT_NUM_GRPC_CHANNELS = "4";
   private static final String MAX_COMMIT_DELAY_PROP_KEY = "maxCommitDelayMillis";
+  private static final String SANITIZE_KEYSPACE_KEY = "sanitizeKeyspace";
 
   public static void main(String[] args) throws Exception {
     final String databaseUri = System.getProperty(DATABASE_URI_PROP_KEY);
@@ -86,6 +87,8 @@ public class SpannerCassandraLauncher {
       throw new IllegalArgumentException(
           "Spanner database URI not set. Please set it using -DdatabaseUri option.");
     }
+    final boolean sanitizeKeyspace =
+        Boolean.parseBoolean(System.getProperty(SANITIZE_KEYSPACE_KEY));
 
     Adapter adapter =
         new Adapter(
@@ -94,7 +97,8 @@ public class SpannerCassandraLauncher {
             inetAddress,
             port,
             numGrpcChannels,
-            maxCommitDelay);
+            maxCommitDelay,
+            sanitizeKeyspace);
 
     Runtime.getRuntime()
         .addShutdownHook(


### PR DESCRIPTION
This fix holds the assumption that the keyspace must be exactly the same with database name from databaseUri.
- Parse keyspace name from databaseUri
- Store a boolean to indicate if keyspace contains hyphen,
- Sanitize all incoming queries from query message by replacing hyphen with underscore.

Please note that for use statement, if the keysapce contains hyphen the keyspace must be wrapped in double quotes. `session.execute("USE my-db")` will automatically transfer to `USE "my-db"` by cassandra driver. In cqlsh we have to manually add doubel quotes around "my-db".

Sample sanitized before&after query:
```
cql before sanitizing: select * from test-hyphen.AllCqlDataTypes where col_text='test-hyphen';
cql after sanitizing: select * from test_hyphen.AllCqlDataTypes where col_text='test-hyphen';

cql before sanitizing: USE "test-hyphen"
cql after sanitizing: USE "test_hyphen"
```

Note that literal values wrapped in single quote will not be sanitized. 