### PR TITLE
perf: only decode bytes to frame for query, execute and batch messages

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -147,7 +147,10 @@ final class DriverConnectionHandler implements Runnable {
         } else {
           outputStream.write(
               adapterClientWrapper.sendGrpcRequest(
-                  ctx.payload, prepareResult.getAttachments(), prepareResult.getContext(), streamId));
+                  ctx.payload,
+                  prepareResult.getAttachments(),
+                  prepareResult.getContext(),
+                  streamId));
           // Now response holds the gRPC result, which might still be empty.
         }
       } catch (RuntimeException e) {
@@ -239,7 +242,7 @@ final class DriverConnectionHandler implements Runnable {
   }
 
   private short load16BigEndian(byte[] bytes, int offset) {
-    return ByteBuffer.wrap(bytes, offset, 2).getShort();
+    return (short) (((bytes[offset] & 0xFF) << 8) | ((bytes[offset + 1] & 0xFF)));
   }
 
   private int load8Unsigned(byte[] bytes, int offset) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -16,24 +16,6 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
-import static com.google.cloud.spanner.adapter.util.StringUtils.startsWith;
-
-import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
-import com.datastax.oss.protocol.internal.Compressor;
-import com.datastax.oss.protocol.internal.Frame;
-import com.datastax.oss.protocol.internal.FrameCodec;
-import com.datastax.oss.protocol.internal.request.Batch;
-import com.datastax.oss.protocol.internal.request.Execute;
-import com.datastax.oss.protocol.internal.request.Query;
-import com.google.api.gax.grpc.GrpcCallContext;
-import com.google.api.gax.rpc.ApiCallContext;
-import com.google.common.collect.ImmutableMap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -48,8 +30,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.datastax.oss.protocol.internal.request.Execute;
+import com.datastax.oss.protocol.internal.request.Query;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.rpc.ApiCallContext;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
+import static com.google.cloud.spanner.adapter.util.StringUtils.startsWith;
+import com.google.common.collect.ImmutableMap;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 
 /** Handles the connection from a driver, translating TCP data to gRPC requests and vice versa. */
 final class DriverConnectionHandler implements Runnable {
@@ -127,17 +130,17 @@ final class DriverConnectionHandler implements Runnable {
     while (true) {
       int streamId = defaultStreamId; // Initialize with a default value.
       try {
-        // 1. Read and construct the payload from the input stream
-        byte[] payload = constructPayload(inputStream);
+        // 1. Read and construct the message context from the input stream
+        MessageContext ctx = constructMessageContext(inputStream);
 
         // 2. Check for EOF signaled by an empty payload
-        if (payload.length == 0) {
+        if (ctx.payload.length == 0) {
           break; // Break out of the loop gracefully in case of EOF
         }
 
         // 3. Prepare the payload.
-        PreparePayloadResult prepareResult = preparePayload(payload);
-        streamId = prepareResult.getStreamId();
+        PreparePayloadResult prepareResult = preparePayload(ctx);
+        streamId = ctx.streamId;
 
         // 4. If attachment preparation didn't yield an immediate response, send the gRPC request.
         if (prepareResult.getAttachmentErrorResponse().isPresent()) {
@@ -145,7 +148,7 @@ final class DriverConnectionHandler implements Runnable {
         } else {
           outputStream.write(
               adapterClientWrapper.sendGrpcRequest(
-                  payload, prepareResult.getAttachments(), prepareResult.getContext(), streamId));
+                  ctx.payload, prepareResult.getAttachments(), prepareResult.getContext(), streamId));
           // Now response holds the gRPC result, which might still be empty.
         }
       } catch (RuntimeException e) {
@@ -185,18 +188,39 @@ final class DriverConnectionHandler implements Runnable {
     return totalBytesRead;
   }
 
-  private byte[] constructPayload(InputStream socketInputStream)
+  class MessageContext {
+    public final byte[] payload;
+    public final int opCode;
+    public final short streamId;
+
+    public MessageContext(int opCode, short streamId, byte[] payload) {
+      this.opCode = opCode;
+      this.payload = payload;
+      this.streamId = streamId;
+    }
+
+    public MessageContext() {
+      payload = new byte[0];
+      opCode = -1;
+      streamId = -1;
+    }
+  }
+
+  private MessageContext constructMessageContext(InputStream socketInputStream)
       throws IOException, IllegalArgumentException {
     byte[] header = new byte[HEADER_LENGTH];
     int bytesRead = readNBytesJava8(socketInputStream, header, 0, HEADER_LENGTH);
     if (bytesRead == 0) {
-      return new byte[0]; // EOF
+      return new MessageContext(); // EOF
     } else if (bytesRead < HEADER_LENGTH) {
       throw new IllegalArgumentException("Payload is not well formed.");
     }
 
-    // Extract the body length from the header.
+    // Extract the body length, op code and stream id from the header.
     int bodyLength = load32BigEndian(header, 5);
+    int opCode = load8Unsigned(header, 4);
+    short streamId = load16BigEndian(header, 2);
+
     if (bodyLength < 0) {
       throw new IllegalArgumentException("Payload is not well formed.");
     }
@@ -208,11 +232,28 @@ final class DriverConnectionHandler implements Runnable {
       throw new IllegalArgumentException("Payload is not well formed.");
     }
 
-    return payload;
+    return new MessageContext(opCode, streamId, payload);
   }
 
   private int load32BigEndian(byte[] bytes, int offset) {
     return ByteBuffer.wrap(bytes, offset, 4).getInt();
+  }
+
+  private short load16BigEndian(byte[] bytes, int offset) {
+    return ByteBuffer.wrap(bytes, offset, 2).getShort();
+  }
+
+  private int load8Unsigned(byte[] bytes, int offset) {
+    // Directly access the byte and apply the 0xFF mask.
+    // This promotes the byte to an int and ensures the value is treated as unsigned.
+    return bytes[offset] & 0xFF;
+  }
+
+  private Frame decodeFrame(byte[] payload) {
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    Frame frame = serverFrameCodec.decode(payloadBuf);
+    payloadBuf.release();
+    return frame;
   }
 
   /**
@@ -225,22 +266,22 @@ final class DriverConnectionHandler implements Runnable {
    * query to the attachments map. If a prepared query is not found, it sets an error in the result
    * object.
    *
-   * @param payload The payload to process.
+   * @param MessageContext The context contains the stream id, op code and payload to process.
    * @return A {@link PreparePayloadResult} containing the result of the operation.
    */
-  private PreparePayloadResult preparePayload(byte[] payload) {
-    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
-    Frame frame = serverFrameCodec.decode(payloadBuf);
-    payloadBuf.release();
-
-    if (frame.message instanceof Execute) {
-      return prepareExecuteMessage((Execute) frame.message, frame.streamId);
-    } else if (frame.message instanceof Batch) {
-      return prepareBatchMessage((Batch) frame.message, frame.streamId);
-    } else if (frame.message instanceof Query) {
-      return prepareQueryMessage((Query) frame.message, frame.streamId);
-    } else {
-      return new PreparePayloadResult(DEFAULT_CONTEXT, frame.streamId);
+  private PreparePayloadResult preparePayload(MessageContext ctx) {
+    switch (ctx.opCode) {
+      case ProtocolConstants.Opcode.EXECUTE:
+        return prepareExecuteMessage(
+            (Execute) decodeFrame(ctx.payload).message, ctx.streamId);
+      case ProtocolConstants.Opcode.BATCH:
+        return prepareBatchMessage(
+            (Batch) decodeFrame(ctx.payload).message, ctx.streamId);
+      case ProtocolConstants.Opcode.QUERY:
+        return prepareQueryMessage(
+            (Query) decodeFrame(ctx.payload).message, ctx.streamId);
+      default:
+        return new PreparePayloadResult(DEFAULT_CONTEXT);
     }
   }
 
@@ -258,7 +299,7 @@ final class DriverConnectionHandler implements Runnable {
     }
     Optional<byte[]> errorResponse =
         prepareAttachmentForQueryId(streamId, attachments, message.queryId);
-    return new PreparePayloadResult(context, streamId, attachments, errorResponse);
+    return new PreparePayloadResult(context, attachments, errorResponse);
   }
 
   private PreparePayloadResult prepareBatchMessage(Batch message, int streamId) {
@@ -278,7 +319,7 @@ final class DriverConnectionHandler implements Runnable {
         delay -> attachments.put(MAX_COMMIT_DELAY_ATTACHMENT_KEY, delay));
     // No error, return with populated attachments.
     return new PreparePayloadResult(
-        DEFAULT_CONTEXT_WITH_LAR, streamId, attachments, attachmentErrorResponse);
+        DEFAULT_CONTEXT_WITH_LAR, attachments, attachmentErrorResponse);
   }
 
   private PreparePayloadResult prepareQueryMessage(Query message, int streamId) {
@@ -293,7 +334,7 @@ final class DriverConnectionHandler implements Runnable {
         attachments.put(MAX_COMMIT_DELAY_ATTACHMENT_KEY, maxCommitDelayMillis.get());
       }
     }
-    return new PreparePayloadResult(context, streamId, attachments);
+    return new PreparePayloadResult(context, attachments);
   }
 
   private Optional<byte[]> prepareAttachmentForQueryId(

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/PreparePayloadResult.java
@@ -27,29 +27,25 @@ import java.util.Optional;
  */
 public class PreparePayloadResult {
   private ApiCallContext context;
-  private int streamId;
   private Map<String, String> attachments;
   private Optional<byte[]> attachmentErrorResponse;
   private static final Map<String, String> EMPTY_ATTACHMENTS = Collections.emptyMap();
 
   public PreparePayloadResult(
       ApiCallContext context,
-      int streamId,
       Map<String, String> attachments,
       Optional<byte[]> attachmentErrorResponse) {
     this.context = context;
-    this.streamId = streamId;
     this.attachments = attachments;
     this.attachmentErrorResponse = attachmentErrorResponse;
   }
 
-  public PreparePayloadResult(
-      ApiCallContext context, int streamId, Map<String, String> attachments) {
-    this(context, streamId, attachments, Optional.empty());
+  public PreparePayloadResult(ApiCallContext context, Map<String, String> attachments) {
+    this(context, attachments, Optional.empty());
   }
 
-  public PreparePayloadResult(ApiCallContext context, int streamId) {
-    this(context, streamId, EMPTY_ATTACHMENTS, Optional.empty());
+  public PreparePayloadResult(ApiCallContext context) {
+    this(context, EMPTY_ATTACHMENTS, Optional.empty());
   }
 
   public Map<String, String> getAttachments() {
@@ -62,9 +58,5 @@ public class PreparePayloadResult {
 
   public ApiCallContext getContext() {
     return context;
-  }
-
-  int getStreamId() {
-    return streamId;
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -16,22 +16,9 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -49,13 +36,24 @@ import com.datastax.oss.protocol.internal.request.Prepare;
 import com.datastax.oss.protocol.internal.request.Query;
 import com.datastax.oss.protocol.internal.request.query.QueryOptions;
 import com.google.api.gax.rpc.ApiCallContext;
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
 import com.google.common.collect.ImmutableList;
-import static com.google.common.truth.Truth.assertThat;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public final class DriverConnectionHandlerTest {
 

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -16,9 +16,22 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
-import static com.google.common.truth.Truth.assertThat;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,24 +49,13 @@ import com.datastax.oss.protocol.internal.request.Prepare;
 import com.datastax.oss.protocol.internal.request.Query;
 import com.datastax.oss.protocol.internal.request.query.QueryOptions;
 import com.google.api.gax.rpc.ApiCallContext;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
 import com.google.common.collect.ImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 public final class DriverConnectionHandlerTest {
 


### PR DESCRIPTION
Skip decoding bytes buffer to frame for unneeded message types. 
We still decode entire frame for QUERY, EXECUTE and BATCH for now. Manually decoding is different due to custom payload flag unless we implement a complete set of custom message codec in this repo. 
