### PR TITLE
enhance: add a custom retry policy for transient spanner errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This client acts as a local tcp proxy, intercepting the raw Cassandra protocol b
   - [Sidecar Proxy (or Standalone Process)](#sidecar-proxy)
 - [Supported Cassandra Versions](#supported-cassandra-versions)
 - [Unsupported Features](#unsupported-features)
+- [Custom Retry Policy](#custom-retry-policy)
 - [License](#license)
 
 ## When to Use Spanner Cassandra Java Client?
@@ -167,6 +168,10 @@ By default, Spanner Cassandra client communicates using the [Cassandra 4.0 proto
 
 * named parameters
 * unset parameter value
+
+## Custom Retry Policy
+
+The Spanner Cassandra Java Client includes a custom retry policy that is tailored for Spanner Server. For more details on how to use and configure this policy, please see the [Custom Retry Policy documentation](docs/retry-policy.md).
 
 ## License
 

--- a/docs/retry-policy.md
+++ b/docs/retry-policy.md
@@ -30,6 +30,7 @@ datastax-java-driver {
   advanced.retry-policy {
     class = com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy
   }
+  ...
 }
 ```
 
@@ -40,7 +41,7 @@ import com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy;
 ...
 CqlSession session =
         SpannerCqlSession.builder()
-            .setDatabaseUri(projects/your_project/instances/your_instance/databases/your_db)
+            .setDatabaseUri("projects/your_project/instances/your_instance/databases/your_db")
             .addContactEndPoint(yourEndpoint) 
             .withLocalDatacenter("datacenter1")
             .withConfigLoader(

--- a/docs/retry-policy.md
+++ b/docs/retry-policy.md
@@ -1,0 +1,52 @@
+# Custom Retry Policy
+
+The Spanner Cassandra driver provides a custom retry policy that is tailored for interacting with Spanner. This policy, `com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy`, extends the default retry behavior of the DataStax Java driver to intelligently handle Spanner-specific transient errors.
+
+## Why Use a Custom Retry Policy?
+
+Spanner may return specific ReadFailure/WriteFailure messages for transient issues that are safe to retry. The default retry policies in the DataStax driver are not aware of these Spanner-specific errors. The `SpannerCqlRetryPolicy` inspects the error messages from Spanner and will trigger a retry for errors that are known to be transient. This improves the resilience of your application and helps it recover from temporary server-side issues without propagating the error to the application layer.
+
+The policy currently retries on the following error messages:
+- `HTTP/2 error code: INTERNAL_ERROR`
+- `Connection closed with unknown cause`
+- `Received unexpected EOS on DATA frame from server`
+- `stream terminated by RST_STREAM`
+- `Authentication backend internal server error. Please retry.`
+- `DEADLINE_EXCEEDED`
+- `ABORTED`
+- `RESOURCE_EXHAUSTED`
+- `UNAVAILABLE`
+
+The policy will retry up to 10 times before re-throwing the exception.
+
+## How to Configure the Retry Policy
+
+You can configure the retry policy in your `application.conf` file. This file is loaded by the DataStax driver when the `CqlSession` is created. You need to specify the custom retry policy class for the execution profiles that you want to use it.
+
+Here is an example of how to set the `SpannerCqlRetryPolicy` as the default retry policy:
+
+```
+datastax-java-driver {
+  advanced.retry-policy {
+    class = com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy
+  }
+}
+```
+
+You can also configure the policy programmatically in Java:
+
+```java
+import com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy;
+...
+CqlSession session =
+        SpannerCqlSession.builder()
+            .setDatabaseUri(projects/your_project/instances/your_instance/databases/your_db)
+            .addContactEndPoint(yourEndpoint) 
+            .withLocalDatacenter("datacenter1")
+            .withConfigLoader(
+                DriverConfigLoader.programmaticBuilder()
+                    .withString(DefaultDriverOption.PROTOCOL_VERSION, "V4")
+                    .withClass(DefaultDriverOption.RETRY_POLICY_CLASS, SpannerCqlRetryPolicy.class)
+                    .build())
+            .build();
+```

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicy.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicy.java
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.google.cloud.spanner.adapter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.retry.RetryDecision;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
+import com.datastax.oss.driver.api.core.servererrors.ReadFailureException;
+import com.datastax.oss.driver.api.core.servererrors.WriteFailureException;
+import com.datastax.oss.driver.api.core.servererrors.WriteType;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+
+/**
+ * A custom retry policy for Cloud Spanner's Cassandra API.
+ *
+ * <p>This policy inspects the error message of ServerError exceptions (which wrap ReadFailure and
+ * WriteFailure). If the message contains Spanner-specific transient error strings like
+ * "DEADLINE_EXCEEDED" or "ABORTED", it triggers a retry.
+ *
+ * <p>For all other cases, it delegates the decision to the default retry policy, preserving the
+ * standard driver behavior.
+ */
+public class SpannerCqlRetryPolicy implements RetryPolicy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerCqlRetryPolicy.class);
+  private final RetryPolicy delegate;
+  private static final int MAX_RETRIES = 10;
+
+  private static final ImmutableList<String> RETRYABLE_ERROR_MESSAGES =
+      ImmutableList.of(
+          "HTTP/2 error code: INTERNAL_ERROR",
+          "Connection closed with unknown cause",
+          "Received unexpected EOS on DATA frame from server",
+          "stream terminated by RST_STREAM",
+          "Authentication backend internal server error. Please retry.",
+          "DEADLINE_EXCEEDED",
+          "ABORTED",
+          "RESOURCE_EXHAUSTED",
+          "UNAVAILABLE");
+
+  /**
+   * Constructor that the driver will invoke.
+   *
+   * @param context The driver context.
+   * @param profileName The name of the execution profile this policy is for.
+   */
+  public SpannerCqlRetryPolicy(DriverContext context, String profileName) {
+    // We delegate to the default policy for all non-Spanner-specific cases.
+    this.delegate = new DefaultRetryPolicy(context, profileName);
+  }
+
+  private boolean isRetryableSpanServerError(CoordinatorException e) {
+    if (!(e instanceof WriteFailureException || e instanceof ReadFailureException)) {
+      return false;
+    }
+    return e.getMessage() != null
+        && RETRYABLE_ERROR_MESSAGES.stream().anyMatch(e.getMessage()::contains);
+  }
+
+  @Override
+  public RetryDecision onErrorResponse(Request request, CoordinatorException e, int retryCount) {
+    String errorMessage = e.getMessage();
+
+    // The Spanner proxy embeds the gRPC error message in the message string of WriteFailure and
+    // ReadFailure frame.
+    // We check for transient gRPC errors that are safe to retry.
+    if (isRetryableSpanServerError(e)) {
+      if (retryCount > MAX_RETRIES) {
+        LOG.error(
+            "Request with Spanner-specific transient error failed after hitting max retries ({})."
+                + " Last error: {}",
+            MAX_RETRIES,
+            errorMessage);
+        return RetryDecision.RETHROW;
+      }
+      LOG.warn(
+          "Spanner-specific transient error detected: '{}'. Retrying query (attempt {}).",
+          errorMessage,
+          retryCount + 1);
+      // Retry on the same node since Spanner is interpreted as a single node to Cassandra
+      // driver.
+      return RetryDecision.RETRY_SAME;
+    }
+
+    // For any other error, fall back to the default driver behavior.
+    return delegate.onErrorResponse(request, e, retryCount);
+  }
+
+  // --- Delegate all other methods to the default policy ---
+  @Override
+  public RetryDecision onReadTimeout(
+      Request request,
+      ConsistencyLevel cl,
+      int blockFor,
+      int received,
+      boolean dataPresent,
+      int retryCount) {
+    return delegate.onReadTimeout(request, cl, blockFor, received, dataPresent, retryCount);
+  }
+
+  @Override
+  public RetryDecision onWriteTimeout(
+      Request request,
+      ConsistencyLevel cl,
+      WriteType writeType,
+      int blockFor,
+      int received,
+      int retryCount) {
+    return delegate.onWriteTimeout(request, cl, writeType, blockFor, received, retryCount);
+  }
+
+  @Override
+  public RetryDecision onUnavailable(
+      Request request, ConsistencyLevel cl, int required, int alive, int retryCount) {
+    return delegate.onUnavailable(request, cl, required, alive, retryCount);
+  }
+
+  @Override
+  public RetryDecision onRequestAborted(Request request, Throwable error, int retryCount) {
+    return delegate.onRequestAborted(request, error, retryCount);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicyTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicyTest.java
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.google.cloud.spanner.adapter;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryDecision;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.servererrors.ReadFailureException;
+import com.datastax.oss.driver.api.core.servererrors.WriteFailureException;
+import com.datastax.oss.driver.api.core.session.Request;
+
+@RunWith(JUnit4.class)
+public class SpannerCqlRetryPolicyTest {
+
+  private SpannerCqlRetryPolicy policy;
+  private Request request;
+  private Node node;
+
+  @Before
+  public void setUp() {
+    DriverContext context = mock(DriverContext.class);
+    policy = new SpannerCqlRetryPolicy(context, "default");
+    request = mock(Request.class);
+    node = mock(Node.class);
+    EndPoint endpoint = mock(EndPoint.class);
+    when(node.getEndPoint()).thenReturn(endpoint);
+    when(endpoint.resolve()).thenReturn(new InetSocketAddress("localhost", 9042));
+  }
+
+  @Test
+  public void testOnErrorResponse_writeFailure_retryable() {
+    WriteFailureException e = mock(WriteFailureException.class);
+    when(e.getMessage()).thenReturn("Spanner UNAVAILABLE");
+    RetryDecision decision = policy.onErrorResponse(request, e, 0);
+    assertEquals(RetryDecision.RETRY_SAME, decision);
+  }
+
+  @Test
+  public void testOnErrorResponse_readFailure_retryable() {
+    ReadFailureException e = mock(ReadFailureException.class);
+    when(e.getMessage()).thenReturn("Spanner txn ABORTED");
+    RetryDecision decision = policy.onErrorResponse(request, e, 0);
+    assertEquals(RetryDecision.RETRY_SAME, decision);
+  }
+
+  @Test
+  public void testOnErrorResponse_maxRetriesExceeded() {
+    ReadFailureException e = mock(ReadFailureException.class);
+    when(e.getMessage()).thenReturn("Spanner txn ABORTED");
+    RetryDecision decision = policy.onErrorResponse(request, e, 11);
+    assertEquals(RetryDecision.RETHROW, decision);
+  }
+
+  @Test
+  public void testOnErrorResponse_nonRetryableError() {
+    ReadFailureException e = mock(ReadFailureException.class);
+    when(e.getMessage()).thenReturn("Spanner crashed");
+    RetryPolicy mockDelegate = mock(RetryPolicy.class);
+    when(mockDelegate.onErrorResponse(request, e, 0)).thenReturn(RetryDecision.RETHROW);
+    RetryDecision decision = policy.onErrorResponse(request, e, 0);
+    assertEquals(RetryDecision.RETHROW, decision);
+  }
+}

--- a/integration-tests/src/test/java/com/google/cloud/spanner/adapter/utils/SpannerContext.java
+++ b/integration-tests/src/test/java/com/google/cloud/spanner/adapter/utils/SpannerContext.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.google.cloud.spanner.adapter.SpannerCqlRetryPolicy;
 import com.google.cloud.spanner.adapter.SpannerCqlSession;
 import com.google.cloud.spanner.admin.database.v1.DatabaseAdminClient;
 import com.google.cloud.spanner.admin.database.v1.DatabaseAdminSettings;
@@ -117,6 +118,7 @@ public class SpannerContext extends DatabaseContext {
             .withConfigLoader(
                 DriverConfigLoader.programmaticBuilder()
                     .withString(DefaultDriverOption.PROTOCOL_VERSION, "V4")
+                    .withClass(DefaultDriverOption.RETRY_POLICY_CLASS, SpannerCqlRetryPolicy.class)
                     .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofMinutes(5))
                     .withDuration(
                         DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofMinutes(5))


### PR DESCRIPTION
This change introduces a custom retry policy for the Cassandra driver that is specifically designed to handle transient Spanner errors.

Spanner server embeds gRPC error messages within the `WriteFailure` and `ReadFailure` frames of the Cassandra protocol. This new policy inspects these error messages for specific strings that indicate a transient issue (e.g., `DEADLINE_EXCEEDED`, `ABORTED`, `UNAVAILABLE`). 

 For all other error types, the policy delegates to the default retry behavior of the DataStax driver, ensuring that existing retry logic for standard Cassandra errors remains unchanged.

The retryable error message strings are borrowed from [java-spanner](https://github.com/googleapis/java-spanner/blob/bf69b1a64307419931ad9fac2dc120ac8f5cacef/google-cloud-spanner/src/main/java/com/google/cloud/spanner/IsRetryableInternalError.java#L29) plus some resources related grpc error codes.