### PR TITLE
perf: Attachments cache improvements

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
@@ -140,7 +140,8 @@ final class Adapter {
       sessionManager.getSession();
 
       adapterClientWrapper =
-          new AdapterClientWrapper(adapterClient, attachmentsCache, sessionManager);
+          new AdapterClientWrapper(
+              adapterClient, attachmentsCache, sessionManager, options.getMaxCommitDelay());
 
       // Start listening on the specified host and port.
       serverSocket =

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AttachmentsCache.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AttachmentsCache.java
@@ -18,6 +18,9 @@ package com.google.cloud.spanner.adapter;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
+import java.nio.ByteBuffer;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,7 +31,26 @@ import java.util.Optional;
  */
 final class AttachmentsCache {
 
-  private final Cache<String, String> cache;
+  /** The value part of an entry in the attachments cache. */
+  public static class CacheValue {
+    private final Map<String, String> attachments;
+    private final boolean isRead;
+
+    public CacheValue(Map<String, String> attachments, boolean isRead) {
+      this.attachments = ImmutableMap.copyOf(attachments);
+      this.isRead = isRead;
+    }
+
+    public Map<String, String> getAttachments() {
+      return attachments;
+    }
+
+    public boolean isRead() {
+      return isRead;
+    }
+  }
+
+  private final Cache<ByteBuffer, CacheValue> cache;
 
   /**
    * Constructs a new GlobalState with the specified maximum cache size.
@@ -45,7 +67,7 @@ final class AttachmentsCache {
    * @param key The key with which to associate the specified value.
    * @param val The value to be associated with the specified key.
    */
-  void put(String key, String val) {
+  void put(ByteBuffer key, CacheValue val) {
     cache.put(key, val);
   }
 
@@ -53,10 +75,10 @@ final class AttachmentsCache {
    * Retrieves the value associated with the specified key from the cache.
    *
    * @param key The key whose associated value is to be returned.
-   * @return An {@link Optional} containing the String value associated with the key, if present,
-   *     otherwise an empty {@code Optional}.
+   * @return An {@link Optional} containing the {@link CacheValue} associated with the key, if
+   *     present, otherwise an empty {@code Optional}.
    */
-  Optional<String> get(String key) {
+  Optional<CacheValue> get(ByteBuffer key) {
     return Optional.ofNullable(cache.getIfPresent(key));
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterClientWrapperTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/AdapterClientWrapperTest.java
@@ -27,16 +27,21 @@ import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.cloud.spanner.adapter.AttachmentsCache.CacheValue;
 import com.google.protobuf.ByteString;
 import com.google.spanner.adapter.v1.AdaptMessageRequest;
 import com.google.spanner.adapter.v1.AdaptMessageResponse;
 import com.google.spanner.adapter.v1.AdapterClient;
 import com.google.spanner.adapter.v1.Session;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +49,7 @@ public final class AdapterClientWrapperTest {
 
   private final Session mockSession = mock(Session.class);
   private AttachmentsCache attachmentsCache;
+  //   private AttachmentsCache attachmentsCache2;
   private final AdapterClient mockAdapterClient = mock(AdapterClient.class);
   private final ServerStream<AdaptMessageResponse> mockServerStream = mock(ServerStream.class);
   private final ServerStreamingCallable<AdaptMessageRequest, AdaptMessageResponse> mockCallable =
@@ -52,27 +58,39 @@ public final class AdapterClientWrapperTest {
   private final ApiCallContext context = GrpcCallContext.createDefault();
 
   private AdapterClientWrapper adapterClientWrapper;
+  private AdapterClientWrapper adapterClientWrapperWithDelay;
 
   public AdapterClientWrapperTest() {}
 
   @Before
   public void setUp() {
     attachmentsCache = new AttachmentsCache(5);
+    // attachmentsCache2 = new AttachmentsCache(5);
     when(mockAdapterClient.adaptMessageCallable()).thenReturn(mockCallable);
     when(mockCallable.call(any(AdaptMessageRequest.class), any(ApiCallContext.class)))
         .thenReturn(mockServerStream);
     when(mockSessionManager.getSession()).thenReturn(mockSession);
     when(mockSession.getName()).thenReturn("test-session");
     adapterClientWrapper =
-        new AdapterClientWrapper(mockAdapterClient, attachmentsCache, mockSessionManager);
+        new AdapterClientWrapper(
+            mockAdapterClient, attachmentsCache, mockSessionManager, Optional.empty());
+    adapterClientWrapperWithDelay =
+        new AdapterClientWrapper(
+            mockAdapterClient,
+            attachmentsCache,
+            mockSessionManager,
+            Optional.of(Duration.ofMillis(100L)));
   }
 
   @Test
   public void sendGrpcRequest_SuccessfulResponse() {
+    System.out.println("sendGrpcRequest_SuccessfulResponse");
     int streamId = 1;
     byte[] payload = "test payload".getBytes();
     Map<String, String> stateUpdates = new HashMap<>();
-    stateUpdates.put("k1", "v1");
+    String queryId = "W_query1";
+    String preparedQueryKey = AdapterClientWrapper.PREPARED_QUERY_ID_ATTACHMENT_PREFIX + queryId;
+    stateUpdates.put(preparedQueryKey, "v1");
     stateUpdates.put("k2", "v2");
     AdaptMessageResponse mockResponse =
         AdaptMessageResponse.newBuilder()
@@ -94,16 +112,25 @@ public final class AdapterClientWrapperTest {
 
     verify(mockCallable).call(expectedRequest, context);
     assertThat(response).isEqualTo(ByteString.copyFromUtf8("test response"));
-    assertThat(attachmentsCache.get("k1")).hasValue("v1");
-    assertThat(attachmentsCache.get("k2")).hasValue("v2");
+    Optional<CacheValue> cacheValue =
+        attachmentsCache.get(ByteBuffer.wrap(queryId.getBytes(StandardCharsets.UTF_8)));
+    assertThat(cacheValue.isPresent()).isTrue();
+    assertThat(cacheValue.get().isRead()).isFalse();
+    Map<String, String> attachments = cacheValue.get().getAttachments();
+    assertThat(attachments.size()).isEqualTo(2);
+    assertThat(attachments.get(preparedQueryKey)).isEqualTo("v1");
+    assertThat(attachments.get("k2")).isEqualTo("v2");
   }
 
   @Test
   public void sendGrpcRequest_MultipleResponses() {
+    System.out.println("sendGrpcRequest_MultipleResponses");
     int streamId = 1;
     byte[] payload = "test payload".getBytes();
     Map<String, String> stateUpdates1 = new HashMap<>();
-    stateUpdates1.put("k1", "v1");
+    String query1 = "W_query1";
+    String preparedQuery1 = AdapterClientWrapper.PREPARED_QUERY_ID_ATTACHMENT_PREFIX + query1;
+    stateUpdates1.put(preparedQuery1, "v1");
     stateUpdates1.put("k2", "v2");
     AdaptMessageResponse mockResponse1 =
         AdaptMessageResponse.newBuilder()
@@ -111,7 +138,9 @@ public final class AdapterClientWrapperTest {
             .putAllStateUpdates(stateUpdates1)
             .build();
     Map<String, String> stateUpdates2 = new HashMap<>();
-    stateUpdates2.put("k3", "v3");
+    String query2 = "R_query2";
+    String preparedQuery2 = AdapterClientWrapper.PREPARED_QUERY_ID_ATTACHMENT_PREFIX + query2;
+    stateUpdates2.put(preparedQuery2, "v3");
     AdaptMessageResponse mockResponse2 =
         AdaptMessageResponse.newBuilder()
             .setPayload(ByteString.copyFromUtf8(" test response 2"))
@@ -132,14 +161,30 @@ public final class AdapterClientWrapperTest {
             .build();
 
     ByteString response =
-        adapterClientWrapper.sendGrpcRequest(payload, new HashMap<>(), context, streamId);
+        adapterClientWrapperWithDelay.sendGrpcRequest(payload, new HashMap<>(), context, streamId);
 
     verify(mockCallable).call(expectedRequest, context);
     assertThat(response)
         .isEqualTo(ByteString.copyFromUtf8("test header test response 1 test response 2"));
-    assertThat(attachmentsCache.get("k1")).hasValue("v1");
-    assertThat(attachmentsCache.get("k2")).hasValue("v2");
-    assertThat(attachmentsCache.get("k3")).hasValue("v3");
+
+    Optional<CacheValue> cacheValue1 =
+        attachmentsCache.get(ByteBuffer.wrap(query1.getBytes(StandardCharsets.UTF_8)));
+    assertThat(cacheValue1.isPresent()).isTrue();
+    assertThat(cacheValue1.get().isRead()).isFalse();
+    Map<String, String> attachments1 = cacheValue1.get().getAttachments();
+    assertThat(attachments1.size()).isEqualTo(3);
+    assertThat(attachments1.get(preparedQuery1)).isEqualTo("v1");
+    assertThat(attachments1.get("k2")).isEqualTo("v2");
+    assertThat(attachments1.get(AdapterClientWrapper.MAX_COMMIT_DELAY_ATTACHMENT_KEY))
+        .isEqualTo("100");
+
+    Optional<CacheValue> cacheValue2 =
+        attachmentsCache.get(ByteBuffer.wrap(query2.getBytes(StandardCharsets.UTF_8)));
+    assertThat(cacheValue2.isPresent()).isTrue();
+    assertThat(cacheValue2.get().isRead()).isTrue();
+    Map<String, String> attachments2 = cacheValue2.get().getAttachments();
+    assertThat(attachments2.size()).isEqualTo(1);
+    assertThat(attachments2.get(preparedQuery2)).isEqualTo("v3");
   }
 
   @Test


### PR DESCRIPTION
This commit refactors the AttachmentsCache to precompute and cache more data to improve the performance of Execute queries.

Key changes include:

### Refactored AttachmentsCache:
* The cache key is now a ByteBuffer instead of byte[] to ensure correct hashing and equality checks, improving cache lookup reliability and performance.

* The cache value is now a dedicated CacheValue object that stores a pre-computed map of attachments and an isRead flag.

### Centralized Logic in AdapterClientWrapper:

* A new processStateUpdates method centralizes the logic for parsing server responses.

* It determines if a prepared query is a read or write operation and adds the max_commit_delay to the attachments for write queries if the option is configured. This pre-processing simplifies the logic in the connection handler.

### Simplified DriverConnectionHandler:

* The handler no longer performs complex logic to determine the context or attachments for prepared statements.

* It now fetches the CacheValue from the cache and directly uses the isRead flag to set the gRPC context and the pre-computed attachments map.

* It remains responsible for adding max_commit_delay for ad-hoc DML queries.

### Updated Unit Tests:

All unit tests for AttachmentsCache, AdapterClientWrapper, and DriverConnectionHandler have been updated and fixed to reflect these architectural changes, ensuring the new logic is thoroughly validated.