### PR TITLE
perf: small optimizations to reduce CPU overhead on hot paths

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
@@ -72,6 +72,9 @@ final class AdapterClientWrapper {
             .setName(sessionManager.getSession().getName())
             .setProtocol("cassandra")
             .putAllAttachments(attachments)
+            // It is safe to use UnsafeByteOperations to wrap the payload without copying, as the
+            // underlying `payload` byte array is not modified after this point. This avoids an
+            // unnecessary memory copy for every request, which is a performance optimization.
             .setPayload(UnsafeByteOperations.unsafeWrap(payload))
             .build();
 

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
@@ -21,6 +21,7 @@ import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErro
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import com.google.spanner.adapter.v1.AdaptMessageRequest;
 import com.google.spanner.adapter.v1.AdaptMessageResponse;
 import com.google.spanner.adapter.v1.AdapterClient;
@@ -71,7 +72,7 @@ final class AdapterClientWrapper {
             .setName(sessionManager.getSession().getName())
             .setProtocol("cassandra")
             .putAllAttachments(attachments)
-            .setPayload(ByteString.copyFrom(payload))
+            .setPayload(UnsafeByteOperations.unsafeWrap(payload))
             .build();
 
     List<ByteString> collectedPayloads = new ArrayList<>();

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -382,13 +383,12 @@ final class DriverConnectionHandler implements Runnable {
   }
 
   private static String constructKey(byte[] queryId) {
-    ByteBuffer key = ByteBuffer.wrap(queryId);
-    String attachmentKey = ATTACHMENT_KEY_CACHE.getIfPresent(key);
-    if (attachmentKey == null) {
-      attachmentKey =
-          PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8);
-      ATTACHMENT_KEY_CACHE.put(key, attachmentKey);
+    try {
+      return ATTACHMENT_KEY_CACHE.get(
+          ByteBuffer.wrap(queryId),
+          () -> PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8));
+    } catch (ExecutionException e) {
+      return PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8);
     }
-    return attachmentKey;
   }
 }

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -32,8 +32,6 @@ import com.datastax.oss.protocol.internal.request.Query;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.cloud.spanner.adapter.metrics.BuiltInMetricsRecorder;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import io.netty.buffer.ByteBuf;
@@ -45,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -54,7 +51,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,8 +66,6 @@ final class DriverConnectionHandler implements Runnable {
   private static final ByteBufAllocator byteBufAllocator = ByteBufAllocator.DEFAULT;
   private static final FrameCodec<ByteBuf> serverFrameCodec =
       FrameCodec.defaultServer(new ByteBufPrimitiveCodec(byteBufAllocator), Compressor.none());
-  private static final Cache<ByteBuffer, String> ATTACHMENT_KEY_CACHE =
-      CacheBuilder.newBuilder().maximumSize(10_000).build();
   private final Socket socket;
   private final AdapterClientWrapper adapterClientWrapper;
   private final Optional<String> maxCommitDelayMillis;
@@ -383,12 +377,6 @@ final class DriverConnectionHandler implements Runnable {
   }
 
   private static String constructKey(byte[] queryId) {
-    try {
-      return ATTACHMENT_KEY_CACHE.get(
-          ByteBuffer.wrap(queryId),
-          () -> PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8));
-    } catch (ExecutionException e) {
-      return PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8);
-    }
+    return PREPARED_QUERY_ID_ATTACHMENT_PREFIX + new String(queryId, StandardCharsets.UTF_8);
   }
 }

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsProvider.java
@@ -23,7 +23,9 @@ import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.DA
 import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.INSTANCE_CONFIG_ID_KEY;
 import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.INSTANCE_ID_KEY;
 import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.LOCATION_ID_KEY;
+import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.METHOD_KEY;
 import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.PROJECT_ID_KEY;
+import static com.google.cloud.spanner.adapter.metrics.BuiltInMetricsConstant.STATUS_KEY;
 
 import com.google.api.gax.core.GaxProperties;
 import com.google.cloud.opentelemetry.detection.AttributeKeys;
@@ -48,8 +50,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -121,14 +121,16 @@ public final class BuiltInMetricsProvider {
     return attributesBuilder.build();
   }
 
-  public Map<String, String> createDefaultAttributes(String databaseId) {
-    Map<String, String> defaultAttributes = new HashMap<>();
-    defaultAttributes.put(DATABASE_KEY.getKey(), databaseId);
-    defaultAttributes.put(
+  public Attributes createDefaultAttributes(String databaseId) {
+    AttributesBuilder defaultAttributesBuilder = Attributes.builder();
+    defaultAttributesBuilder.put(DATABASE_KEY.getKey(), databaseId);
+    defaultAttributesBuilder.put(
         CLIENT_NAME_KEY.getKey(),
         "spanner-cassandra-java/" + GaxProperties.getLibraryVersion(getClass()));
-    defaultAttributes.put(CLIENT_UID_KEY.getKey(), getDefaultTaskValue());
-    return defaultAttributes;
+    defaultAttributesBuilder.put(CLIENT_UID_KEY.getKey(), getDefaultTaskValue());
+    defaultAttributesBuilder.put(METHOD_KEY.getKey(), "Adapter.AdaptMessage");
+    defaultAttributesBuilder.put(STATUS_KEY.getKey(), "OK");
+    return defaultAttributesBuilder.build();
   }
 
   /**

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsProvider.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsProvider.java
@@ -117,19 +117,19 @@ public final class BuiltInMetricsProvider {
             .put(INSTANCE_ID_KEY.getKey(), instanceId)
             .put(LOCATION_ID_KEY.getKey(), detectClientLocation())
             .put("gcp.resource_type", BuiltInMetricsConstant.SPANNER_RESOURCE_TYPE);
-
     return attributesBuilder.build();
   }
 
   public Attributes createDefaultAttributes(String databaseId) {
-    AttributesBuilder defaultAttributesBuilder = Attributes.builder();
-    defaultAttributesBuilder.put(DATABASE_KEY.getKey(), databaseId);
-    defaultAttributesBuilder.put(
-        CLIENT_NAME_KEY.getKey(),
-        "spanner-cassandra-java/" + GaxProperties.getLibraryVersion(getClass()));
-    defaultAttributesBuilder.put(CLIENT_UID_KEY.getKey(), getDefaultTaskValue());
-    defaultAttributesBuilder.put(METHOD_KEY.getKey(), "Adapter.AdaptMessage");
-    defaultAttributesBuilder.put(STATUS_KEY.getKey(), "OK");
+    AttributesBuilder defaultAttributesBuilder =
+        Attributes.builder()
+            .put(DATABASE_KEY.getKey(), databaseId)
+            .put(
+                CLIENT_NAME_KEY.getKey(),
+                "spanner-cassandra-java/" + GaxProperties.getLibraryVersion(getClass()))
+            .put(CLIENT_UID_KEY.getKey(), getDefaultTaskValue())
+            .put(METHOD_KEY.getKey(), "Adapter.AdaptMessage")
+            .put(STATUS_KEY.getKey(), "OK");
     return defaultAttributesBuilder.build();
   }
 

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsRecorder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/metrics/BuiltInMetricsRecorder.java
@@ -16,21 +16,18 @@ limitations under the License.
 package com.google.cloud.spanner.adapter.metrics;
 
 import com.google.api.gax.core.GaxProperties;
-import com.google.common.base.Preconditions;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
-import java.util.Map;
 
 /** Implementation for recording built in metrics. */
 public final class BuiltInMetricsRecorder {
 
   private final LongCounter operationCountRecorder;
   private final DoubleHistogram operationLatencyRecorder;
-  private final Map<String, String> defaultAttr;
+  private final Attributes defaultAttr;
 
   /**
    * Creates the following instruments for the following metrics:
@@ -43,7 +40,7 @@ public final class BuiltInMetricsRecorder {
    * @param openTelemetry OpenTelemetry instance
    * @param defaultAttr Default attibutes
    */
-  public BuiltInMetricsRecorder(OpenTelemetry openTelemetry, Map<String, String> defaultAttr) {
+  public BuiltInMetricsRecorder(OpenTelemetry openTelemetry, Attributes defaultAttr) {
     Meter meter =
         openTelemetry
             .meterBuilder(BuiltInMetricsConstant.SPANNER_METER_NAME)
@@ -72,19 +69,11 @@ public final class BuiltInMetricsRecorder {
     this.defaultAttr = defaultAttr;
   }
 
-  public void recordOperationLatency(double operationLatency, Map<String, String> attributes) {
-    operationLatencyRecorder.record(operationLatency, toOtelAttributes(attributes));
+  public void recordOperationLatency(double operationLatency) {
+    operationLatencyRecorder.record(operationLatency, defaultAttr);
   }
 
-  public void recordOperationCount(long count, Map<String, String> attributes) {
-    operationCountRecorder.add(count, toOtelAttributes(attributes));
-  }
-
-  Attributes toOtelAttributes(Map<String, String> attributes) {
-    Preconditions.checkNotNull(attributes, "Attributes map cannot be null");
-    AttributesBuilder attributesBuilder = Attributes.builder();
-    attributes.forEach(attributesBuilder::put);
-    this.defaultAttr.forEach(attributesBuilder::put);
-    return attributesBuilder.build();
+  public void recordOperationCount(long count) {
+    operationCountRecorder.add(count, defaultAttr);
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -73,8 +73,6 @@ public final class DriverConnectionHandlerTest {
   private AdapterClientWrapper mockAdapterClient;
   private Socket mockSocket;
   private ByteArrayOutputStream outputStream;
-  private static final Map<String, String> expectedAttributes =
-      ImmutableMap.of("method", "Adapter.AdaptMessage", "status", "OK");
 
   public DriverConnectionHandlerTest() {}
 
@@ -206,7 +204,7 @@ public final class DriverConnectionHandlerTest {
         .containsExactly("x-goog-spanner-route-to-leader", ImmutableList.of("true"));
     assertThat(attachmentsCaptor.getValue())
         .containsExactly(preparedQueryKey, "query", "max_commit_delay", "100");
-    verify(mockMetricsRecorder).recordOperationCount(1L, expectedAttributes);
+    verify(mockMetricsRecorder).recordOperationCount(1L);
   }
 
   @Test
@@ -249,7 +247,7 @@ public final class DriverConnectionHandlerTest {
         .sendGrpcRequest(any(), any(), contextCaptor.capture(), any(int.class));
     assertThat(contextCaptor.getValue().getExtraHeaders())
         .containsExactly("x-goog-spanner-route-to-leader", ImmutableList.of("true"));
-    verify(mockMetricsRecorder).recordOperationCount(1L, expectedAttributes);
+    verify(mockMetricsRecorder).recordOperationCount(1L);
   }
 
   @Test


### PR DESCRIPTION
This PR implements several targeted optimizations to reduce CPU overhead on hot paths. The changes focus on:

*   **Minimizing data copying**: Utilizing `UnsafeByteOperations.unsafeWrap` for request payload to avoid redundant `ByteString` copies.
*   **Optimizing metrics**: Precomputing OpenTelemetry `Attributes` to reduce allocation and overhead per metric record.