### PR TITLE
enhance: retry grpc errors with custom retry policy

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterClientWrapper.java
@@ -16,20 +16,22 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
-
-import com.google.api.gax.rpc.ApiCallContext;
-import com.google.api.gax.rpc.ServerStream;
-import com.google.protobuf.ByteString;
-import com.google.spanner.adapter.v1.AdaptMessageRequest;
-import com.google.spanner.adapter.v1.AdaptMessageResponse;
-import com.google.spanner.adapter.v1.AdapterClient;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ServerStream;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unavailableErrorResponse;
+import com.google.protobuf.ByteString;
+import com.google.spanner.adapter.v1.AdaptMessageRequest;
+import com.google.spanner.adapter.v1.AdaptMessageResponse;
+import com.google.spanner.adapter.v1.AdapterClient;
 
 /** Wraps an {@link AdapterClient} to manage gRPC communication with the Adapter service. */
 final class AdapterClientWrapper {
@@ -85,8 +87,8 @@ final class AdapterClientWrapper {
       }
     } catch (RuntimeException e) {
       LOG.error("Error executing AdaptMessage request: ", e);
-      // Any error in getting the AdaptMessageResponse should be reported back to the client.
-      return serverErrorResponse(streamId, e.getMessage());
+      // Any grpc exception should be reported back to the client as a retryable unavailable error.
+      return unavailableErrorResponse(streamId, e.getMessage());
     }
 
     if (collectedPayloads.isEmpty()) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -16,27 +16,6 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
-import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
-import static com.google.cloud.spanner.adapter.util.StringUtils.startsWith;
-
-import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
-import com.datastax.oss.protocol.internal.Compressor;
-import com.datastax.oss.protocol.internal.Frame;
-import com.datastax.oss.protocol.internal.FrameCodec;
-import com.datastax.oss.protocol.internal.ProtocolConstants;
-import com.datastax.oss.protocol.internal.request.Batch;
-import com.datastax.oss.protocol.internal.request.Execute;
-import com.datastax.oss.protocol.internal.request.Query;
-import com.google.api.gax.grpc.GrpcCallContext;
-import com.google.api.gax.rpc.ApiCallContext;
-import com.google.cloud.spanner.adapter.metrics.BuiltInMetricsRecorder;
-import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.ByteString;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -51,8 +30,31 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.request.Batch;
+import com.datastax.oss.protocol.internal.request.Execute;
+import com.datastax.oss.protocol.internal.request.Query;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.cloud.spanner.adapter.metrics.BuiltInMetricsRecorder;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
+import static com.google.cloud.spanner.adapter.util.StringUtils.startsWith;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 
 /** Handles the connection from a driver, translating TCP data to gRPC requests and vice versa. */
 final class DriverConnectionHandler implements Runnable {
@@ -171,7 +173,7 @@ final class DriverConnectionHandler implements Runnable {
         }
       } catch (RuntimeException e) {
         // 5. Handle any error during payload construction or attachment processing.
-        // Create a server error response to send back to the client.
+        // Create an server error response to send back to the client to trigger retry.
         LOG.error("Error processing request: ", e);
         response =
             serverErrorResponse(

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/util/ErrorMessageUtils.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/util/ErrorMessageUtils.java
@@ -16,18 +16,22 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter.util;
 
+import java.util.Collections;
+
 import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
 import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.ProtocolConstants.ErrorCode;
 import com.datastax.oss.protocol.internal.response.Error;
+import com.datastax.oss.protocol.internal.response.error.Unavailable;
 import com.datastax.oss.protocol.internal.response.error.Unprepared;
 import com.google.api.core.InternalApi;
 import com.google.protobuf.ByteString;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import java.util.Collections;
 
 /**
  * Utility class for creating specific types of error response frames used in the server protocol,
@@ -72,6 +76,18 @@ public final class ErrorMessageUtils {
    */
   public static ByteString serverErrorResponse(int streamId, String message) {
     Error errorMsg = new Error(ErrorCode.SERVER_ERROR, message);
+    return errorResponse(streamId, errorMsg);
+  }
+
+  /**
+   * Creates a server error message response.
+   *
+   * @param streamId The stream id of the message.
+   * @param message The error message.
+   * @return A {@link ByteString} representing the server error response.
+   */
+  public static ByteString unavailableErrorResponse(int streamId, String message) {
+    Error errorMsg = new Unavailable(message, ProtocolConstants.ConsistencyLevel.QUORUM, 1, 1);
     return errorResponse(streamId, errorMsg);
   }
 

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -17,6 +17,7 @@ limitations under the License.
 package com.google.cloud.spanner.adapter;
 
 import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.serverErrorResponse;
+import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unavailableErrorResponse;;
 import static com.google.cloud.spanner.adapter.util.ErrorMessageUtils.unpreparedResponse;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicyTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/SpannerCqlRetryPolicyTest.java
@@ -16,10 +16,17 @@ limitations under the License.
 
 package com.google.cloud.spanner.adapter;
 
+import java.net.InetSocketAddress;
+
 import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.metadata.Node;
@@ -28,11 +35,6 @@ import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.servererrors.ReadFailureException;
 import com.datastax.oss.driver.api.core.servererrors.WriteFailureException;
 import com.datastax.oss.driver.api.core.session.Request;
-import java.net.InetSocketAddress;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class SpannerCqlRetryPolicyTest {
@@ -50,6 +52,12 @@ public class SpannerCqlRetryPolicyTest {
     EndPoint endpoint = mock(EndPoint.class);
     when(node.getEndPoint()).thenReturn(endpoint);
     when(endpoint.resolve()).thenReturn(new InetSocketAddress("localhost", 9042));
+  }
+
+  @Test
+  public void testOnUnavailable() {
+    RetryDecision decision = policy.onUnavailable(request, ConsistencyLevel.LOCAL_QUORUM, 3, 2, 0);
+    assertEquals(RetryDecision.RETRY_SAME, decision);
   }
 
   @Test


### PR DESCRIPTION
Also modify custom retry policy to retry on same node for unavailable errors, since Spanner is interpreted as a single node Cassandra server.