### PR TITLE
ci: Introduce NoSQLBench benchmark workflow

### DIFF
--- a/.github/config/driver.conf
+++ b/.github/config/driver.conf
@@ -1,0 +1,8 @@
+# Configuration file for the CQL driver used by the NoSQLBench workflow.
+datastax-java-driver {
+  advanced.protocol.version = V4
+  advanced.connection {
+    pool.local.size = 2
+  }
+  basic.request.timeout = 100 seconds
+}

--- a/.github/config/keyvalue_workload.yaml
+++ b/.github/config/keyvalue_workload.yaml
@@ -1,0 +1,23 @@
+description: "A simple read/write workload for the Spanner Cassandra adapter."
+
+blocks:
+  - name: main_read
+    params:
+      ratio: 6
+    statements:
+      - select_row: |
+          select * from keyvalue
+          where key={srch_key};
+        bindings:
+          srch_key: Uniform(1,100000) -> int
+
+  - name: main_write
+    params:
+      ratio: 4
+    statements:
+      - insert_row: |
+          insert into keyvalue (key, value)
+          values ({row_key}, {row_value});
+        bindings:
+          row_key: Uniform(1,10000000) -> int
+          row_value: FirstNames()

--- a/.github/scripts/start-adapter.sh
+++ b/.github/scripts/start-adapter.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script starts the Spanner Cassandra Adapter and waits for it to be healthy.
+
+# Exit immediately if a command exits with a non-zero status, and also exit if any command in a pipeline fails.
+set -eo pipefail
+
+# Find the launcher JAR file.
+LAUNCHER_JAR=$(find google-cloud-spanner-cassandra/target -name "spanner-cassandra-launcher.jar")
+if [ -z "$LAUNCHER_JAR" ]; then
+  echo "Error: spanner-cassandra-launcher.jar not found."
+  exit 1
+fi
+
+# Base parameters for the adapter.
+ADAPTER_PARAMS="-Dhost=127.0.0.1 -Dport=9042 -DhealthCheckPort=8080 -DdatabaseUri=$NOSQLBENCH_DATABASE_URI"
+
+# Add the Spanner endpoint parameter only for the 'devel' environment.
+# The MATRIX_ENVIRONMENT variable is passed from the GitHub Actions workflow.
+if [ "$MATRIX_ENVIRONMENT" = "devel" ]; then
+  ADAPTER_PARAMS="$ADAPTER_PARAMS -DspannerEndpoint=$SPANNER_ENDPOINT"
+fi
+
+echo "Starting adapter with params: $ADAPTER_PARAMS"
+# Start the adapter in the background (&) so the workflow can proceed.
+java $ADAPTER_PARAMS -jar $LAUNCHER_JAR &
+
+# Health check logic.
+echo "Waiting for adapter to start..."
+timeout=60
+# Poll the /debug/health endpoint until it returns a 200 OK status.
+# The `curl -sf` command fails silently (returns a non-zero exit code) on HTTP errors,
+# causing the loop to continue until a successful response is received.
+while ! curl -sf http://127.0.0.1:8080/debug/health > /dev/null; do
+  # Fail the workflow if the adapter doesn't start within the timeout period.
+  if [ $timeout -le 0 ]; then
+    echo "Adapter did not start within 60 seconds."
+    exit 1
+  fi
+  sleep 5
+  timeout=$((timeout - 5))
+done
+
+echo "Adapter started successfully."

--- a/.github/workflows/nosqlbench-benchmark.yml
+++ b/.github/workflows/nosqlbench-benchmark.yml
@@ -1,0 +1,73 @@
+name: NoSQLBench Daily Benchmark
+
+# TODO: Set a daily schedule once this workflow has been tested.
+on:
+  workflow_dispatch: # Enable manual runs
+
+env:
+  NOSQLBENCH_JAR_URL: https://github.com/nosqlbench/nosqlbench/releases/download/5.17.9-release/nb5.jar
+  NOSQLBENCH_JAR: /tmp/nb5.jar
+  NOSQLBENCH_WORKLOAD: ./.github/config/keyvalue_workload.yaml
+  NOSQLBENCH_DRIVER_CONFIG: ./.github/config/driver.conf
+
+jobs:
+  nosqlbench_benchmark:
+    runs-on: ubuntu-latest
+    strategy:
+      # Do not cancel other jobs in the matrix if one fails. This ensures that a
+      # failure in the 'devel' environment does not prevent the 'prod' benchmark from running.
+      fail-fast: false
+      matrix:
+        environment: [prod, devel]
+        java: [11]
+    outputs:
+      status: ${{ job.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.SPANNER_CASSANDRA_ADAPTER_CICD_SERVICE_ACCOUNT }}'
+      - name: Download NoSQLBench
+        run: curl -L $NOSQLBENCH_JAR_URL -o $NOSQLBENCH_JAR
+      - name: Build with Maven
+        run: mvn clean package -DskipTests
+      - name: Start Adapter
+        env:
+          NOSQLBENCH_DATABASE_URI: ${{ secrets.NOSQLBENCH_DATABASE_URI }}
+          SPANNER_ENDPOINT: ${{ secrets.SPANNER_DEVEL_ENDPOINT }}
+          GOOGLE_SPANNER_CASSANDRA_LOG_SERVER_ERRORS: true
+          MATRIX_ENVIRONMENT: ${{ matrix.environment }}
+        run: |
+          chmod +x ./.github/scripts/start-adapter.sh
+          ./.github/scripts/start-adapter.sh
+      - name: Run NoSQLBench
+        run: |
+          java -jar $NOSQLBENCH_JAR -v start workload=$NOSQLBENCH_WORKLOAD driver=cqld4 localdc=datacenter1 \
+          cycles=50000 threads=5 host=127.0.0.1 port=9042 driverconfig=$NOSQLBENCH_DRIVER_CONFIG --progress console:10s
+
+  notify_on_failure:
+    runs-on: ubuntu-latest
+    needs: [nosqlbench_benchmark]
+    if: needs.nosqlbench_benchmark.result == 'failure'
+    strategy:
+      matrix:
+        environment: [prod, devel]
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on failure
+        if: needs.nosqlbench_benchmark.outputs[matrix.environment] == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 [${{ matrix.environment }}] Daily NoSQLBench benchmark failed!`,
+              body: `The ${{ matrix.environment }} benchmark job failed. See [failed run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+            });


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to run a performance benchmark using NoSQLBench against both production and development environments. The initial implementation will only support manual runs but it will be configured to run daily once it's been tested.

The primary goal of this workflow is to proactively detect performance regressions by running a consistent workload over time.

Key features of this implementation include:

- A matrix strategy to efficiently test both `prod` and `devel` environments without code duplication.
- A robust health check in a dedicated script (`.github/scripts/start-adapter.sh`) that waits for the adapter to be fully available before starting the test.
- Specific, per-environment failure notifications that create a targeted GitHub issue if a benchmark fails.
- A simple read/write workload defined in `spanner_workload.yaml`.