### PR TITLE
ci: Update NoSQLBench workflow to Java 17 and fix notifications

### DIFF
--- a/.github/workflows/nosqlbench-benchmark.yml
+++ b/.github/workflows/nosqlbench-benchmark.yml
@@ -19,16 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         environment: [prod, devel]
-        java: [11]
-    outputs:
-      status: ${{ job.status }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: 17
       - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.SPANNER_CASSANDRA_ADAPTER_CICD_SERVICE_ACCOUNT }}'
@@ -49,19 +46,8 @@ jobs:
         run: |
           java -jar $NOSQLBENCH_JAR -v start workload=$NOSQLBENCH_WORKLOAD driver=cqld4 localdc=datacenter1 \
           cycles=50000 threads=5 host=127.0.0.1 port=9042 driverconfig=$NOSQLBENCH_DRIVER_CONFIG --progress console:10s
-
-  notify_on_failure:
-    runs-on: ubuntu-latest
-    needs: [nosqlbench_benchmark]
-    if: needs.nosqlbench_benchmark.result == 'failure'
-    strategy:
-      matrix:
-        environment: [prod, devel]
-    permissions:
-      issues: write
-    steps:
-      - name: Create issue on failure
-        if: needs.nosqlbench_benchmark.outputs[matrix.environment] == 'failure'
+      - name: Notify on failure
+        if: failure()
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Updates the NoSQLBench benchmark workflow to use Java 17, which is now required to run the nosqlbench JAR.

Also, refactors the failure notification logic. The previous implementation had a separate job that was not reliably triggered on single matrix failures. This change moves the notification to a step inside the benchmark job that runs if any preceding step fails, ensuring a notification is created for each failed environment.