### PR TITLE
ci: Enable built-in metrics for the Adapter in NoSQLBench workflow

### DIFF
--- a/.github/scripts/start-adapter.sh
+++ b/.github/scripts/start-adapter.sh
@@ -27,7 +27,7 @@ if [ -z "$LAUNCHER_JAR" ]; then
 fi
 
 # Base parameters for the adapter.
-ADAPTER_PARAMS="-Dhost=127.0.0.1 -Dport=9042 -DhealthCheckPort=8080 -DdatabaseUri=$NOSQLBENCH_DATABASE_URI"
+ADAPTER_PARAMS="-Dhost=127.0.0.1 -Dport=9042 -DhealthCheckPort=8080 -DenableBuiltInMetrics=true -DdatabaseUri=$NOSQLBENCH_DATABASE_URI"
 
 # Add the Spanner endpoint parameter only for the 'devel' environment.
 # The MATRIX_ENVIRONMENT variable is passed from the GitHub Actions workflow.

--- a/.github/workflows/nosqlbench-benchmark.yml
+++ b/.github/workflows/nosqlbench-benchmark.yml
@@ -14,7 +14,10 @@ env:
 jobs:
   nosqlbench_benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    timeout-minutes: 60
     strategy:
       # Do not cancel other jobs in the matrix if one fails. This ensures that a
       # failure in the 'devel' environment does not prevent the 'prod' benchmark from running.


### PR DESCRIPTION
Also update the permissions for the job to be able to create issues for failures, and increase the job timeout to reduce notification noise.