### PR TITLE
chore: Reduce the number of threads from 1024 to 512

### DIFF
--- a/integration-tests/src/test/java/com/google/cloud/spanner/adapter/MultithreadedIT.java
+++ b/integration-tests/src/test/java/com/google/cloud/spanner/adapter/MultithreadedIT.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 /** Extension of BasicIT with multiple threads. */
 public class MultithreadedIT extends AbstractIT {
 
-  private static final int NUM_THREADS = 1024;
+  private static final int NUM_THREADS = 512;
   private static final int TIMEOUT_MINUTES = 5;
 
   public MultithreadedIT(DatabaseContext db) {


### PR DESCRIPTION
If 1024 requests are fired simultaneously, then it can cause heartbeat exception because the default number of max requests per connection is 1024.