### PR TITLE
feat: expose options to override spanner endpoint and talking to spanner insecurely.

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Adapter.java
@@ -32,6 +32,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.spanner.adapter.v1.AdapterClient;
 import com.google.spanner.adapter.v1.AdapterSettings;
+import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -92,6 +93,9 @@ final class Adapter {
       if (credentials == null) {
         credentials = GoogleCredentials.getApplicationDefault();
       }
+      if (options.insecure()) {
+        credentials = null;
+      }
       final CredentialsProvider credentialsProvider = setUpCredentialsProvider(credentials);
 
       InstantiatingGrpcChannelProvider.Builder channelProviderBuilder =
@@ -100,6 +104,11 @@ final class Adapter {
       if (options.getUseVirtualThreads()) {
         executor = tryCreateVirtualThreadPerTaskExecutor("spanner-virtual-thread");
         channelProviderBuilder.setExecutor(executor);
+      }
+
+      if (options.insecure()) {
+        LOG.warn("Using insecure channel. This should not be used in production.");
+        channelProviderBuilder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
       }
 
       channelProviderBuilder

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterOptions.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/AdapterOptions.java
@@ -40,6 +40,7 @@ class AdapterOptions {
     private Credentials credentials;
     private BuiltInMetricsRecorder metricsRecorder;
     private boolean useVirtualThreads = false;
+    private boolean insecure = false;
 
     /** The Cloud Spanner endpoint. */
     Builder spannerEndpoint(String spannerEndpoint) {
@@ -106,6 +107,12 @@ class AdapterOptions {
       return this;
     }
 
+    /** (Optional) Whether to enable insecure mode when connecting to Spanner */
+    Builder insecure(boolean insecure) {
+      this.insecure = insecure;
+      return this;
+    }
+
     AdapterOptions build() {
       return new AdapterOptions(this);
     }
@@ -121,6 +128,7 @@ class AdapterOptions {
   private Credentials credentials;
   private BuiltInMetricsRecorder metricsRecorder;
   private boolean useVirtualThreads;
+  private boolean insecure;
 
   private AdapterOptions(Builder builder) {
     this.spannerEndpoint = builder.spannerEndpoint;
@@ -133,6 +141,7 @@ class AdapterOptions {
     this.credentials = builder.credentials;
     this.metricsRecorder = builder.metricsRecorder;
     this.useVirtualThreads = builder.useVirtualThreads;
+    this.insecure = builder.insecure;
   }
 
   static Builder newBuilder() {
@@ -177,5 +186,9 @@ class AdapterOptions {
 
   BuiltInMetricsRecorder getMetricsRecorder() {
     return metricsRecorder;
+  }
+
+  boolean insecure() {
+    return insecure;
   }
 }

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Launcher.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/Launcher.java
@@ -224,7 +224,8 @@ public class Launcher {
             .databaseUri(config.getDatabaseUri())
             .inetAddress(config.getHostAddress())
             .numGrpcChannels(config.getNumGrpcChannels())
-            .metricsRecorder(metricsRecorder);
+            .metricsRecorder(metricsRecorder)
+            .insecure(config.insecure());
     if (config.getMaxCommitDelayMillis() != null) {
       opBuilder.maxCommitDelay(Duration.ofMillis(config.getMaxCommitDelayMillis()));
     }
@@ -245,13 +246,15 @@ public class Launcher {
   private void startAdapter(ListenerConfig config) throws IOException {
     LOG.info(
         "Starting Adapter for Spanner database {} on {}:{} with {} gRPC channels, max commit"
-            + " delay of {} and built-in metrics enabled: {}",
+            + " delay of {}, built-in metrics enabled: {}, insecure: {}, spanner endpoint: {}",
         config.getDatabaseUri(),
         config.getHostAddress(),
         config.getPort(),
         config.getNumGrpcChannels(),
         config.getMaxCommitDelayMillis(),
-        config.isEnableBuiltInMetrics());
+        config.isEnableBuiltInMetrics(),
+        config.insecure(),
+        config.getSpannerEndpoint());
 
     final DatabaseName databaseName = DatabaseName.parse(config.getDatabaseUri());
     final BuiltInMetricsRecorder metricsRecorder =

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/LauncherConfig.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/LauncherConfig.java
@@ -58,6 +58,7 @@ public final class LauncherConfig {
 
     final String globalSpannerEndpoint;
     final boolean globalEnableBuiltInMetrics;
+    final boolean insecure;
     HealthCheckConfig healthCheckConfig = null;
 
     if (userConfigs.getGlobalClientConfigs() != null) {
@@ -73,9 +74,13 @@ public final class LauncherConfig {
             HealthCheckConfig.fromEndpointString(
                 userConfigs.getGlobalClientConfigs().getHealthCheckEndpoint());
       }
+      insecure =
+          userConfigs.getGlobalClientConfigs().getInsecure() != null
+              && userConfigs.getGlobalClientConfigs().getInsecure();
     } else {
       globalSpannerEndpoint = ConfigConstants.DEFAULT_SPANNER_ENDPOINT;
       globalEnableBuiltInMetrics = false;
+      insecure = false;
     }
 
     List<ListenerConfig> listenerConfigs = new ArrayList<>();
@@ -83,7 +88,7 @@ public final class LauncherConfig {
       validateListenerConfig(listener);
       listenerConfigs.add(
           ListenerConfig.fromListenerConfigs(
-              listener, globalSpannerEndpoint, globalEnableBuiltInMetrics));
+              listener, globalSpannerEndpoint, globalEnableBuiltInMetrics, insecure));
     }
 
     return new LauncherConfig(listenerConfigs, healthCheckConfig);
@@ -124,6 +129,7 @@ final class ListenerConfig {
   private final int numGrpcChannels;
   @Nullable private final Integer maxCommitDelayMillis;
   private final boolean enableBuiltInMetrics;
+  private final boolean insecure;
 
   private ListenerConfig(Builder builder) {
     this.databaseUri = builder.databaseUri;
@@ -133,6 +139,7 @@ final class ListenerConfig {
     this.numGrpcChannels = builder.numGrpcChannels;
     this.maxCommitDelayMillis = builder.maxCommitDelayMillis;
     this.enableBuiltInMetrics = builder.enableBuiltInMetrics;
+    this.insecure = builder.insecure;
   }
 
   public String getDatabaseUri() {
@@ -164,8 +171,15 @@ final class ListenerConfig {
     return enableBuiltInMetrics;
   }
 
+  public boolean insecure() {
+    return insecure;
+  }
+
   static ListenerConfig fromListenerConfigs(
-      ListenerConfigs listener, String globalSpannerEndpoint, boolean globalEnableBuiltInMetrics)
+      ListenerConfigs listener,
+      String globalSpannerEndpoint,
+      boolean globalEnableBuiltInMetrics,
+      boolean insecure)
       throws UnknownHostException {
     String host = listener.getHost() != null ? listener.getHost() : ConfigConstants.DEFAULT_HOST;
     int port = listener.getPort() != null ? listener.getPort() : ConfigConstants.DEFAULT_PORT;
@@ -183,6 +197,7 @@ final class ListenerConfig {
         .numGrpcChannels(numGrpcChannels)
         .maxCommitDelayMillis(maxCommitDelayMillis)
         .enableBuiltInMetrics(globalEnableBuiltInMetrics)
+        .insecure(insecure)
         .build();
   }
 
@@ -193,6 +208,9 @@ final class ListenerConfig {
         Integer.parseInt(
             properties.getOrDefault(
                 ConfigConstants.PORT_PROP_KEY, String.valueOf(ConfigConstants.DEFAULT_PORT)));
+    String spannerEndpoint =
+        properties.getOrDefault(
+            ConfigConstants.SPANNER_ENDPOINT_PROP_KEY, ConfigConstants.DEFAULT_SPANNER_ENDPOINT);
     int numGrpcChannels =
         Integer.parseInt(
             properties.getOrDefault(
@@ -204,15 +222,18 @@ final class ListenerConfig {
     boolean enableBuiltInMetrics =
         Boolean.parseBoolean(
             properties.getOrDefault(ConfigConstants.ENABLE_BUILTIN_METRICS_PROP_KEY, "false"));
+    boolean insecure =
+        Boolean.parseBoolean(properties.getOrDefault(ConfigConstants.INSECURE_PROP_KEY, "false"));
 
     return newBuilder()
         .databaseUri(properties.get(ConfigConstants.DATABASE_URI_PROP_KEY))
         .hostAddress(InetAddress.getByName(host))
         .port(port)
-        .spannerEndpoint(ConfigConstants.DEFAULT_SPANNER_ENDPOINT)
+        .spannerEndpoint(spannerEndpoint)
         .numGrpcChannels(numGrpcChannels)
         .maxCommitDelayMillis(maxCommitDelayMillis)
         .enableBuiltInMetrics(enableBuiltInMetrics)
+        .insecure(insecure)
         .build();
   }
 
@@ -228,6 +249,7 @@ final class ListenerConfig {
     private int numGrpcChannels;
     @Nullable private Integer maxCommitDelayMillis;
     private boolean enableBuiltInMetrics;
+    private boolean insecure;
 
     public Builder databaseUri(String databaseUri) {
       this.databaseUri = databaseUri;
@@ -261,6 +283,16 @@ final class ListenerConfig {
 
     public Builder enableBuiltInMetrics(boolean enableBuiltInMetrics) {
       this.enableBuiltInMetrics = enableBuiltInMetrics;
+      return this;
+    }
+
+    public Builder insecure(String insecure) {
+      this.insecure = Boolean.parseBoolean(insecure);
+      return this;
+    }
+
+    public Builder insecure(boolean insecure) {
+      this.insecure = insecure;
       return this;
     }
 

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/SpannerCqlSessionBuilder.java
@@ -65,6 +65,7 @@ public final class SpannerCqlSessionBuilder
   private TransportChannelProvider channelProvider = null;
   private Credentials credentials;
   private boolean useVirtualThreads;
+  private boolean insecure;
 
   /**
    * Wraps the default CQL session with a SpannerCqlSession instance.
@@ -142,6 +143,15 @@ public final class SpannerCqlSessionBuilder
    */
   protected SpannerCqlSessionBuilder setUseVirtualThreads(boolean useVirtualThreads) {
     this.useVirtualThreads = useVirtualThreads;
+    return this;
+  }
+
+  /**
+   * (Optional, default `false`) Enables/disables insecure (plaintext) connections to the Spanner
+   * endpoint. This should only be used for testing against a local fake Spanner instance.
+   */
+  public SpannerCqlSessionBuilder setInsecure(boolean insecure) {
+    this.insecure = insecure;
     return this;
   }
 
@@ -270,6 +280,7 @@ public final class SpannerCqlSessionBuilder
             .maxCommitDelay(maxCommitDelay.orElse(null))
             .metricsRecorder(metricsRecorder)
             .useVirtualThreads(useVirtualThreads)
+            .insecure(insecure)
             .build();
     adapter = new Adapter(adapterOptions);
     adapter.start();

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/configs/ConfigConstants.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/configs/ConfigConstants.java
@@ -23,6 +23,7 @@ public final class ConfigConstants {
   private ConfigConstants() {}
 
   public static final String DEFAULT_SPANNER_ENDPOINT = "spanner.googleapis.com:443";
+  public static final String SPANNER_ENDPOINT_PROP_KEY = "spannerEndpoint";
   public static final String DATABASE_URI_PROP_KEY = "databaseUri";
   public static final String HOST_PROP_KEY = "host";
   public static final String PORT_PROP_KEY = "port";
@@ -34,4 +35,5 @@ public final class ConfigConstants {
   public static final String ENABLE_BUILTIN_METRICS_PROP_KEY = "enableBuiltInMetrics";
   public static final String HEALTH_CHECK_PORT_PROP_KEY = "healthCheckPort";
   public static final String CONFIG_FILE_PROP_KEY = "configFilePath";
+  public static final String INSECURE_PROP_KEY = "insecure";
 }

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/configs/GlobalClientConfigs.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/configs/GlobalClientConfigs.java
@@ -23,19 +23,31 @@ public class GlobalClientConfigs {
   private final String spannerEndpoint;
   private final Boolean enableBuiltInMetrics;
   private final String healthCheckEndpoint;
+  private final Boolean insecure;
 
   public GlobalClientConfigs(
-      String spannerEndpoint, Boolean enableBuiltInMetrics, String healthCheckEndpoint) {
+      String spannerEndpoint,
+      Boolean enableBuiltInMetrics,
+      String healthCheckEndpoint,
+      Boolean insecure) {
     this.spannerEndpoint = spannerEndpoint;
     this.enableBuiltInMetrics = enableBuiltInMetrics;
     this.healthCheckEndpoint = healthCheckEndpoint;
+    this.insecure = insecure;
+  }
+
+  public GlobalClientConfigs(
+      String spannerEndpoint, Boolean enableBuiltInMetrics, String healthCheckEndpoint) {
+    this(spannerEndpoint, enableBuiltInMetrics, healthCheckEndpoint, null);
   }
 
   public static GlobalClientConfigs fromMap(Map<String, Object> yamlMap) {
     String spannerEndpoint = (String) yamlMap.get("spannerEndpoint");
     Boolean enableBuiltInMetrics = (Boolean) yamlMap.get("enableBuiltInMetrics");
     String healthCheckEndpoint = (String) yamlMap.get("healthCheckEndpoint");
-    return new GlobalClientConfigs(spannerEndpoint, enableBuiltInMetrics, healthCheckEndpoint);
+    Boolean insecure = (Boolean) yamlMap.get("insecure");
+    return new GlobalClientConfigs(
+        spannerEndpoint, enableBuiltInMetrics, healthCheckEndpoint, insecure);
   }
 
   public String getSpannerEndpoint() {
@@ -48,5 +60,9 @@ public class GlobalClientConfigs {
 
   public String getHealthCheckEndpoint() {
     return healthCheckEndpoint;
+  }
+
+  public Boolean getInsecure() {
+    return insecure;
   }
 }

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/LauncherConfigParserTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/LauncherConfigParserTest.java
@@ -105,6 +105,28 @@ public class LauncherConfigParserTest {
   }
 
   @Test
+  public void testParse_withValidInsecureConfigFile() throws Exception {
+    String configFile =
+        getClass().getClassLoader().getResource("valid-insecure-config.yaml").getFile();
+    Map<String, String> properties = new HashMap<>();
+    properties.put("configFilePath", configFile);
+
+    LauncherConfig config = LauncherConfigParser.parse(properties);
+
+    assertThat(config.getListeners()).hasSize(2);
+    ListenerConfig listenerConfig1 = config.getListeners().get(0);
+    assertThat(listenerConfig1.getSpannerEndpoint()).isEqualTo("localhost:15000");
+    assertThat(listenerConfig1.insecure()).isTrue();
+
+    ListenerConfig listenerConfig2 = config.getListeners().get(1);
+    assertThat(listenerConfig2.getDatabaseUri())
+        .isEqualTo("projects/my-project/instances/my-instance/databases/my-database-2");
+    assertThat(listenerConfig2.getPort()).isEqualTo(9043);
+    assertThat(listenerConfig2.getSpannerEndpoint()).isEqualTo("localhost:15000");
+    assertThat(listenerConfig2.insecure()).isTrue();
+  }
+
+  @Test
   public void testParse_withSystemProperties() throws Exception {
     Map<String, String> properties = new HashMap<>();
     properties.put("databaseUri", DEFAULT_DATABASE_URI);
@@ -131,6 +153,41 @@ public class LauncherConfigParserTest {
       assertThat(listenerConfig.isEnableBuiltInMetrics()).isTrue();
       assertThat(config.getHealthCheckConfig()).isNotNull();
       assertThat(config.getHealthCheckConfig().getPort()).isEqualTo(8080);
+    }
+  }
+
+  @Test
+  public void testParse_withInsecureSystemProperties() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("databaseUri", DEFAULT_DATABASE_URI);
+    properties.put("host", "127.0.0.1");
+    properties.put("port", "9042");
+    properties.put("numGrpcChannels", "8");
+    properties.put("maxCommitDelayMillis", "100");
+    properties.put("enableBuiltInMetrics", "true");
+    properties.put("healthCheckPort", "8080");
+    properties.put("spannerEndpoint", "localhost:15000");
+    properties.put("insecure", "true");
+
+    try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+      InetAddress mockAddress = mock(InetAddress.class);
+      when(mockAddress.getHostAddress()).thenReturn("127.0.0.1");
+      mockedInetAddress.when(() -> InetAddress.getByName("127.0.0.1")).thenReturn(mockAddress);
+
+      LauncherConfig config = LauncherConfigParser.parse(properties);
+      assertThat(config.getListeners()).hasSize(1);
+      ListenerConfig listenerConfig = config.getListeners().get(0);
+      assertThat(listenerConfig.getDatabaseUri()).isEqualTo(DEFAULT_DATABASE_URI);
+      assertThat(listenerConfig.getPort()).isEqualTo(9042);
+      assertThat(listenerConfig.getHostAddress().getHostAddress()).isEqualTo("127.0.0.1");
+      assertThat(listenerConfig.getNumGrpcChannels()).isEqualTo(8);
+      assertThat(listenerConfig.getMaxCommitDelayMillis()).isEqualTo(100);
+      assertThat(listenerConfig.isEnableBuiltInMetrics()).isTrue();
+      assertThat(config.getHealthCheckConfig()).isNotNull();
+      assertThat(config.getHealthCheckConfig().getPort()).isEqualTo(8080);
+      assertThat(listenerConfig.getSpannerEndpoint()).isNotNull();
+      assertThat(listenerConfig.getSpannerEndpoint()).isEqualTo("localhost:15000");
+      assertThat(listenerConfig.insecure()).isTrue();
     }
   }
 

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/LauncherTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/LauncherTest.java
@@ -111,12 +111,16 @@ public class LauncherTest {
         .isEqualTo("projects/p/instances/i/databases/d-1-config-test");
     assertThat(options1.getTcpPort()).isEqualTo(9042);
     assertThat(options1.getInetAddress()).isEqualTo(InetAddress.getByName("127.0.0.1"));
+    assertThat(options1.getSpannerEndpoint()).isEqualTo("spanner.googleapis.com:443");
+    assertThat(options1.insecure()).isFalse();
 
     AdapterOptions options2 = adapterOptionsCaptor.getAllValues().get(1);
     assertThat(options2.getDatabaseUri())
         .isEqualTo("projects/p/instances/i/databases/d-2-config-test");
     assertThat(options2.getTcpPort()).isEqualTo(9043);
     assertThat(options2.getInetAddress()).isEqualTo(InetAddress.getByName("0.0.0.0"));
+    assertThat(options2.getSpannerEndpoint()).isEqualTo("spanner.googleapis.com:443");
+    assertThat(options2.insecure()).isFalse();
   }
 
   @Test
@@ -145,6 +149,40 @@ public class LauncherTest {
     assertThat(options.getInetAddress()).isEqualTo(InetAddress.getByName("127.0.0.1"));
     assertThat(options.getNumGrpcChannels()).isEqualTo(8);
     assertThat(options.getMaxCommitDelay().get().toMillis()).isEqualTo(100);
+    assertThat(options.getSpannerEndpoint()).isEqualTo("spanner.googleapis.com:443");
+    assertThat(options.insecure()).isFalse();
+  }
+
+  @Test
+  public void testRun_withInsecureMode_startsAdapterWithOptions() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("databaseUri", DEFAULT_DATABASE_URI);
+    properties.put("host", "127.0.0.1");
+    properties.put("port", "9042");
+    properties.put("numGrpcChannels", "8");
+    properties.put("maxCommitDelayMillis", "100");
+    properties.put("enableBuiltInMetrics", "true");
+    properties.put("healthCheckPort", "8080");
+    properties.put("spannerEndpoint", "localhost:15000");
+    properties.put("insecure", "true");
+    LauncherConfig config = LauncherConfig.fromProperties(properties);
+
+    launcher.run(config);
+
+    verify(mockAdapterFactory, times(1)).createAdapter(adapterOptionsCaptor.capture());
+    verify(mockAdapterFactory, times(1)).createHealthCheckServer(any(), eq(8080));
+    verify(mockAdapter, times(1)).start();
+    verify(mockHealthCheckServer).start();
+    verify(mockHealthCheckServer).setReady(true);
+
+    AdapterOptions options = adapterOptionsCaptor.getValue();
+    assertThat(options.getDatabaseUri()).isEqualTo(DEFAULT_DATABASE_URI);
+    assertThat(options.getTcpPort()).isEqualTo(9042);
+    assertThat(options.getInetAddress()).isEqualTo(InetAddress.getByName("127.0.0.1"));
+    assertThat(options.getNumGrpcChannels()).isEqualTo(8);
+    assertThat(options.getMaxCommitDelay().get().toMillis()).isEqualTo(100);
+    assertThat(options.getSpannerEndpoint()).isEqualTo("localhost:15000");
+    assertThat(options.insecure()).isTrue();
   }
 
   @Test

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/configs/YamlConfigLoaderTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/configs/YamlConfigLoaderTest.java
@@ -40,6 +40,7 @@ public class YamlConfigLoaderTest {
       assertThat(userConfigs.getGlobalClientConfigs().getEnableBuiltInMetrics()).isTrue();
       assertThat(userConfigs.getGlobalClientConfigs().getHealthCheckEndpoint())
           .isEqualTo("127.0.0.1:8080");
+      assertThat(userConfigs.getGlobalClientConfigs().getInsecure()).isNull();
 
       List<ListenerConfigs> listeners = userConfigs.getListeners();
       assertThat(listeners).isNotNull();
@@ -74,6 +75,27 @@ public class YamlConfigLoaderTest {
       assertThat(listener2.getSpanner().getNumGrpcChannels()).isEqualTo(8);
 
       assertThat(listener2.getSpanner().getMaxCommitDelayMillis()).isNull();
+    }
+  }
+
+  @Test
+  public void testLoad_validInsecureYamlFile_parsesCorrectly() throws IOException {
+    try (InputStream inputStream =
+        getClass().getClassLoader().getResourceAsStream("valid-insecure-config.yaml")) {
+      UserConfigs userConfigs = YamlConfigLoader.load(inputStream);
+
+      assertThat(userConfigs).isNotNull();
+      assertThat(userConfigs.getGlobalClientConfigs()).isNotNull();
+      assertThat(userConfigs.getGlobalClientConfigs().getSpannerEndpoint())
+          .isEqualTo("localhost:15000");
+      assertThat(userConfigs.getGlobalClientConfigs().getEnableBuiltInMetrics()).isTrue();
+      assertThat(userConfigs.getGlobalClientConfigs().getHealthCheckEndpoint())
+          .isEqualTo("127.0.0.1:8080");
+      assertThat(userConfigs.getGlobalClientConfigs().getInsecure()).isTrue();
+
+      List<ListenerConfigs> listeners = userConfigs.getListeners();
+      assertThat(listeners).isNotNull();
+      assertThat(listeners).hasSize(2);
     }
   }
 

--- a/google-cloud-spanner-cassandra/src/test/resources/valid-insecure-config.yaml
+++ b/google-cloud-spanner-cassandra/src/test/resources/valid-insecure-config.yaml
@@ -1,0 +1,24 @@
+# Global client configuration
+globalClientConfigs:
+  spannerEndpoint: "localhost:15000"
+  enableBuiltInMetrics: true
+  healthCheckEndpoint: "127.0.0.1:8080"
+  insecure: true
+
+# List of all listeners
+listeners:
+  - # Configuration for listener_1
+    name: "listener_1"
+    host: "127.0.0.1"
+    port: 9042
+    spanner:
+      databaseUri: "projects/my-project/instances/my-instance/databases/my-database"
+      numGrpcChannels: 4
+      maxCommitDelayMillis: 100
+  - # Configuration for listener_2
+    name: "listener_2"
+    host: "127.0.0.2"
+    port: 9043
+    spanner:
+      databaseUri: "projects/my-project/instances/my-instance/databases/my-database-2"
+      numGrpcChannels: 8


### PR DESCRIPTION
expose options to override spanner endpoint and talking to spanner insecurely. It will be useful to test with experimental/fake spanner server.

Example usage:
```
java -DdatabaseUri=projects/<project>/instances/<instance>/databases/cassandra \
 -Dhost=0.0.0.0 \
 -Dport=9042 \
 -DnumGrpcChannels=4 \
 -DhealthCheckPort=8080 \
 -Dinsecure=true \
 -DspannerEndpoint=<spanner-endpoint-url>\
 -jar google-cloud-spanner-cassandra/target/spanner-cassandra-launcher.jar
```
