### PR TITLE
fix: upgrade testcontainers to 1.21.4

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -62,7 +62,7 @@
           <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>cassandra</artifactId>
-            <version>1.21.0</version>
+            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrades testcontainers to fix failing integration tests due to an outdated client version error: 'client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version'
