### PR TITLE
feat: support USE keyspace attachments

### DIFF
--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -359,7 +359,6 @@ final class DriverConnectionHandler implements Runnable {
         return preparePrepareMessage();
       default:
         return new PreparePayloadResult(DEFAULT_CONTEXT);
-
     }
   }
 
@@ -410,18 +409,19 @@ final class DriverConnectionHandler implements Runnable {
         attachments.put(MAX_COMMIT_DELAY_ATTACHMENT_KEY, maxCommitDelayMillis.get());
       }
     }
-    Optional<String> keyspace = adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
+    Optional<String> keyspace =
+        adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
     keyspace.ifPresent(v -> attachments.put(KEYSPACE_ATTACHMENT_KEY, v));
     return new PreparePayloadResult(context, attachments);
   }
 
   private PreparePayloadResult preparePrepareMessage() {
     Map<String, String> attachments = new HashMap<>();
-    Optional<String> keyspace = adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
+    Optional<String> keyspace =
+        adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
     keyspace.ifPresent(v -> attachments.put(KEYSPACE_ATTACHMENT_KEY, v));
     return new PreparePayloadResult(DEFAULT_CONTEXT, attachments);
   }
-
 
   private Optional<ByteString> prepareAttachmentForQueryId(
       int streamId, Map<String, String> attachments, byte[] queryId) {

--- a/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
+++ b/google-cloud-spanner-cassandra/src/main/java/com/google/cloud/spanner/adapter/DriverConnectionHandler.java
@@ -71,6 +71,8 @@ final class DriverConnectionHandler implements Runnable {
   private static final char WRITE_ACTION_QUERY_ID_PREFIX = 'W';
   private static final String ROUTE_TO_LEADER_HEADER_KEY = "x-goog-spanner-route-to-leader";
   private static final String MAX_COMMIT_DELAY_ATTACHMENT_KEY = "max_commit_delay";
+  private static final String KEYSPACE_ATTACHMENT_KEY = "keyspace";
+
   private static final ByteBufAllocator byteBufAllocator = ByteBufAllocator.DEFAULT;
   private static final FrameCodec<ByteBuf> serverFrameCodec = customServerCodec(byteBufAllocator);
   private static final FrameCodec<ByteBuf> clientFrameCodec =
@@ -353,8 +355,11 @@ final class DriverConnectionHandler implements Runnable {
         return prepareBatchMessage((Batch) decodeFrame(ctx.payload).message, ctx.streamId);
       case ProtocolConstants.Opcode.QUERY:
         return prepareQueryMessage((Query) decodeFrame(ctx.payload).message);
+      case ProtocolConstants.Opcode.PREPARE:
+        return preparePrepareMessage();
       default:
         return new PreparePayloadResult(DEFAULT_CONTEXT);
+
     }
   }
 
@@ -396,18 +401,27 @@ final class DriverConnectionHandler implements Runnable {
 
   private PreparePayloadResult prepareQueryMessage(Query message) {
     ApiCallContext context;
-    Map<String, String> attachments = Collections.emptyMap();
+    Map<String, String> attachments = new HashMap<>();
     if (startsWith(message.query, "SELECT")) {
       context = DEFAULT_CONTEXT;
     } else {
       context = DEFAULT_CONTEXT_WITH_LAR;
       if (maxCommitDelayMillis.isPresent()) {
-        attachments = new HashMap<>();
         attachments.put(MAX_COMMIT_DELAY_ATTACHMENT_KEY, maxCommitDelayMillis.get());
       }
     }
+    Optional<String> keyspace = adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
+    keyspace.ifPresent(v -> attachments.put(KEYSPACE_ATTACHMENT_KEY, v));
     return new PreparePayloadResult(context, attachments);
   }
+
+  private PreparePayloadResult preparePrepareMessage() {
+    Map<String, String> attachments = new HashMap<>();
+    Optional<String> keyspace = adapterClientWrapper.getAttachmentsCache().get(KEYSPACE_ATTACHMENT_KEY);
+    keyspace.ifPresent(v -> attachments.put(KEYSPACE_ATTACHMENT_KEY, v));
+    return new PreparePayloadResult(DEFAULT_CONTEXT, attachments);
+  }
+
 
   private Optional<ByteString> prepareAttachmentForQueryId(
       int streamId, Map<String, String> attachments, byte[] queryId) {

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -327,7 +327,7 @@ public final class DriverConnectionHandlerTest {
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
     when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any(), any(int.class)))
         .thenReturn(grpcResponse);
-    
+
     AttachmentsCache attachmentsCache = new AttachmentsCache(1);
     attachmentsCache.put("keyspace", "test_keyspace");
     when(mockAdapterClient.getAttachmentsCache()).thenReturn(attachmentsCache);
@@ -339,7 +339,8 @@ public final class DriverConnectionHandlerTest {
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
     verify(mockAdapterClient)
-        .sendGrpcRequest(any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
+        .sendGrpcRequest(
+            any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
     assertThat(attachmentsCaptor.getValue()).containsExactly("keyspace", "test_keyspace");
   }
 
@@ -350,7 +351,7 @@ public final class DriverConnectionHandlerTest {
     when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
     when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any(), any(int.class)))
         .thenReturn(grpcResponse);
-    
+
     AttachmentsCache attachmentsCache = new AttachmentsCache(1);
     attachmentsCache.put("keyspace", "test_keyspace");
     when(mockAdapterClient.getAttachmentsCache()).thenReturn(attachmentsCache);
@@ -362,7 +363,8 @@ public final class DriverConnectionHandlerTest {
     assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
     verify(mockSocket).close();
     verify(mockAdapterClient)
-        .sendGrpcRequest(any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
+        .sendGrpcRequest(
+            any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
     assertThat(attachmentsCaptor.getValue()).containsExactly("keyspace", "test_keyspace");
   }
 

--- a/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
+++ b/google-cloud-spanner-cassandra/src/test/java/com/google/cloud/spanner/adapter/DriverConnectionHandlerTest.java
@@ -82,6 +82,7 @@ public final class DriverConnectionHandlerTest {
     mockSocket = mock(Socket.class);
     outputStream = new ByteArrayOutputStream();
     when(mockSocket.getOutputStream()).thenReturn(outputStream);
+    when(mockAdapterClient.getAttachmentsCache()).thenReturn(new AttachmentsCache(10));
   }
 
   @Test
@@ -317,6 +318,52 @@ public final class DriverConnectionHandlerTest {
 
     assertThat(ByteString.copyFrom(outputStream.toByteArray())).isEqualTo(expectedResponse);
     verify(mockSocket).close();
+  }
+
+  @Test
+  public void successfulQueryMessageWithKeyspace() throws IOException {
+    byte[] validPayload = createQueryMessage();
+    ByteString grpcResponse = ByteString.copyFromUtf8("gRPC response");
+    when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any(), any(int.class)))
+        .thenReturn(grpcResponse);
+    
+    AttachmentsCache attachmentsCache = new AttachmentsCache(1);
+    attachmentsCache.put("keyspace", "test_keyspace");
+    when(mockAdapterClient.getAttachmentsCache()).thenReturn(attachmentsCache);
+
+    DriverConnectionHandler handler =
+        new DriverConnectionHandler(mockSocket, mockAdapterClient, mockMetricsRecorder);
+    handler.run();
+
+    assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
+    verify(mockSocket).close();
+    verify(mockAdapterClient)
+        .sendGrpcRequest(any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
+    assertThat(attachmentsCaptor.getValue()).containsExactly("keyspace", "test_keyspace");
+  }
+
+  @Test
+  public void successfulPrepareMessageWithKeyspace() throws IOException {
+    byte[] validPayload = createPrepareMessage();
+    ByteString grpcResponse = ByteString.copyFromUtf8("gRPC response");
+    when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(validPayload));
+    when(mockAdapterClient.sendGrpcRequest(any(byte[].class), any(), any(), any(int.class)))
+        .thenReturn(grpcResponse);
+    
+    AttachmentsCache attachmentsCache = new AttachmentsCache(1);
+    attachmentsCache.put("keyspace", "test_keyspace");
+    when(mockAdapterClient.getAttachmentsCache()).thenReturn(attachmentsCache);
+
+    DriverConnectionHandler handler =
+        new DriverConnectionHandler(mockSocket, mockAdapterClient, mockMetricsRecorder);
+    handler.run();
+
+    assertThat(outputStream.toString(StandardCharsets.UTF_8.name())).isEqualTo("gRPC response");
+    verify(mockSocket).close();
+    verify(mockAdapterClient)
+        .sendGrpcRequest(any(), attachmentsCaptor.capture(), contextCaptor.capture(), any(int.class));
+    assertThat(attachmentsCaptor.getValue()).containsExactly("keyspace", "test_keyspace");
   }
 
   private static byte[] createQueryMessage() {


### PR DESCRIPTION
Implements client-side attachments for QUERY and PREPARE opcodes to support USE keyspace context.
